### PR TITLE
Add utility methods for extracting components of a composition

### DIFF
--- a/softwareconfiguration/hasco/src/hasco/core/Util.java
+++ b/softwareconfiguration/hasco/src/hasco/core/Util.java
@@ -1,9 +1,14 @@
 package hasco.core;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.math3.geometry.euclidean.oned.Interval;
@@ -207,6 +212,60 @@ public class Util {
   public static ComponentInstance getSolutionCompositionFromState(final Collection<Component> components, final Monom state) {
     return Util.getGroundComponentsFromState(state, components, true).get("solution");
   }
+  
+
+	/**
+	 * Computes a String of component names that appear in the composition which can
+	 * be used as an identifier for the composition
+	 * 
+	 * @param composition
+	 * @return String of all component names in right to left depth-first order
+	 */
+	public static String getComponentNamesOfComposition(ComponentInstance composition) {
+		StringBuilder builder = new StringBuilder();
+		Deque<ComponentInstance> componentInstances = new ArrayDeque<ComponentInstance>();
+		componentInstances.push(composition);
+		ComponentInstance curInstance;
+		while (!componentInstances.isEmpty()) {
+			curInstance = componentInstances.pop();
+			builder.append(curInstance.getComponent().getName());
+			LinkedHashMap<String, String> requiredInterfaces = curInstance.getComponent().getRequiredInterfaces();
+			// This set should be ordered
+			Set<String> requiredInterfaceNames = requiredInterfaces.keySet();
+			for (String requiredInterfaceName : requiredInterfaceNames) {
+				ComponentInstance instance = curInstance.getSatisfactionOfRequiredInterfaces()
+						.get(requiredInterfaceName);
+				componentInstances.push(instance);
+			}
+		}
+		return builder.toString();
+	}
+
+	/**
+	 * Computes a list of all components of the given composition.
+	 * 
+	 * @param composition
+	 * @return List of components in right to left depth-first order
+	 */
+	public static List<Component> getComponentsOfComposition(ComponentInstance composition) {
+		List<Component> components = new LinkedList<Component>();
+		Deque<ComponentInstance> componentInstances = new ArrayDeque<ComponentInstance>();
+		componentInstances.push(composition);
+		ComponentInstance curInstance;
+		while (!componentInstances.isEmpty()) {
+			curInstance = componentInstances.pop();
+			components.add(curInstance.getComponent());
+			LinkedHashMap<String, String> requiredInterfaces = curInstance.getComponent().getRequiredInterfaces();
+			// This set should be ordered
+			Set<String> requiredInterfaceNames = requiredInterfaces.keySet();
+			for (String requiredInterfaceName : requiredInterfaceNames) {
+				ComponentInstance instance = curInstance.getSatisfactionOfRequiredInterfaces()
+						.get(requiredInterfaceName);
+				componentInstances.push(instance);
+			}
+		}
+		return components;
+	}
 
   public static Map<Parameter, ParameterDomain> getUpdatedDomainsOfComponentParameters(final Monom state, final Component component, final String objectIdentifierInState) {
     Map<String, String> parameterContainerMap = new HashMap<>();

--- a/softwareconfiguration/hasco/test/hasco/test/UtilCompositionTest.java
+++ b/softwareconfiguration/hasco/test/hasco/test/UtilCompositionTest.java
@@ -1,0 +1,48 @@
+package hasco.test;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import hasco.core.Util;
+import hasco.model.Component;
+import hasco.model.ComponentInstance;
+
+public class UtilCompositionTest {
+
+	@Test
+	public void test() {
+		Component component1 = new Component("Component1");
+		Component component2 = new Component("Component2");
+		Component component3 = new Component("Component3");
+		Component component4 = new Component("Component4");
+		List<Component> groundTruth = new LinkedList<Component>();
+		groundTruth.add(component1);
+		groundTruth.add(component4);
+		groundTruth.add(component2);
+		groundTruth.add(component3);
+		component1.addRequiredInterface("Interface1", "Interface1");
+		component1.addRequiredInterface("Interface2", "Interface2");
+		component2.addRequiredInterface("Interface1", "Interface1");
+		Map<String,ComponentInstance> sat1 = new HashMap<String,ComponentInstance>();
+		Map<String,ComponentInstance> sat2 = new HashMap<String,ComponentInstance>();
+		Map<String,ComponentInstance> sat3 = new HashMap<String,ComponentInstance>();
+		Map<String,ComponentInstance> sat4 = new HashMap<String,ComponentInstance>();
+		Map<String,String> parameterValues = new HashMap<String,String>();
+		ComponentInstance instance4 = new ComponentInstance(component4, parameterValues, sat4);
+		ComponentInstance instance3 = new ComponentInstance(component3, parameterValues, sat3);
+		sat2.put("Interface1", instance3);
+		ComponentInstance instance2 = new ComponentInstance(component2, parameterValues, sat2);
+		sat1.put("Interface1", instance2);
+		sat1.put("Interface2", instance4);
+		ComponentInstance instance1 = new ComponentInstance(component1, parameterValues, sat1);
+		List<Component> components = Util.getComponentsOfComposition(instance1);
+		for(int i = 0; i < groundTruth.size(); i++)
+			assertEquals(components.get(i), groundTruth.get(i));
+	}
+}


### PR DESCRIPTION
Lukas asked me, if the utility methods for extracting a list/string of components for a composition (ComponentInstance) could be made accessible for all.