### PR TITLE
Add new machine learning interfaces and associated exceptions.

### DIFF
--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/CheckedJaicoreMLException.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/CheckedJaicoreMLException.java
@@ -1,0 +1,34 @@
+package jaicore.ml.core.exception;
+
+/**
+ * The {@link CheckedJaicoreMLException} serves as a base class for all checked {@link Exception}s defined as part of jaicore-ml.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public abstract class CheckedJaicoreMLException extends Exception {
+
+	private static final long serialVersionUID = 7366050163157197392L;
+
+	/**
+	 * Creates a new {@link CheckedJaicoreMLException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 * @param cause
+	 *            The underlying cause of this {@link Exception}.
+	 */
+	public CheckedJaicoreMLException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Creates a new {@link CheckedJaicoreMLException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 */
+	public CheckedJaicoreMLException(String message) {
+		super(message);
+	}
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/ConfigurationException.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/ConfigurationException.java
@@ -1,0 +1,35 @@
+package jaicore.ml.core.exception;
+
+/**
+ * The {@link ConfigurationException} indicates an error during a configuration process. Details concerning the error can be inferred from the associated message.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public class ConfigurationException extends CheckedJaicoreMLException {
+
+	private static final long serialVersionUID = 3979468542526154560L;
+
+	/**
+	 * Creates a new {@link ConfigurationException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 * @param cause
+	 *            The underlying cause of this {@link Exception}.
+	 */
+	public ConfigurationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Creates a new {@link ConfigurationException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 */
+	public ConfigurationException(String message) {
+		super(message);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/PredictionException.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/PredictionException.java
@@ -1,0 +1,35 @@
+package jaicore.ml.core.exception;
+
+/**
+ * The {@link PredictionException} indicates that an error occurred during a prediction process. Details concerning the error can be inferred from the associated message.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public class PredictionException extends CheckedJaicoreMLException {
+
+	private static final long serialVersionUID = -6893506621839121367L;
+
+	/**
+	 * Creates a new {@link PredictionException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 * @param cause
+	 *            The underlying cause of this {@link Exception}.
+	 */
+	public PredictionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Creates a new {@link PredictionException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 */
+	public PredictionException(String message) {
+		super(message);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/TrainingException.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/TrainingException.java
@@ -1,0 +1,35 @@
+package jaicore.ml.core.exception;
+
+/**
+ * The {@link TrainingException} indicates that an error occurred during a training process. Details concerning the error can be inferred from the associated message.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public class TrainingException extends CheckedJaicoreMLException {
+
+	private static final long serialVersionUID = -3684777835122718847L;
+
+	/**
+	 * Creates a new {@link TrainingException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 * @param cause
+	 *            The underlying cause of this {@link Exception}.
+	 */
+	public TrainingException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Creates a new {@link TrainingException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 */
+	public TrainingException(String message) {
+		super(message);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/UncheckedJaicoreMLException.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/UncheckedJaicoreMLException.java
@@ -1,0 +1,35 @@
+package jaicore.ml.core.exception;
+
+/**
+ * The {@link UncheckedJaicoreMLException} serves as a base class for all unchecked {@link Exception}s defined as part of jaicore-ml.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public abstract class UncheckedJaicoreMLException extends RuntimeException {
+
+	private static final long serialVersionUID = 5949039077785112560L;
+
+	/**
+	 * Creates a new {@link UncheckedJaicoreMLException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 * @param cause
+	 *            The underlying cause of this {@link Exception}.
+	 */
+	public UncheckedJaicoreMLException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Creates a new {@link UncheckedJaicoreMLException} with the given parameters.
+	 * 
+	 * @param message
+	 *            The message of this {@link Exception}.
+	 */
+	public UncheckedJaicoreMLException(String message) {
+		super(message);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/exception/package-info.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/exception/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * This package contains {@link java.lang.Exception}s defined by jaicore-ml. Most importantly it contains the two (abstract) base classes {@link jaicore.ml.core.exception.CheckedJaicoreMLException}
+ * and {@link jaicore.ml.core.exception.UncheckedJaicoreMLException} which can be used to catch all exceptions emitted by classes which are part of jaicore-ml.
+ * 
+ * @since 0.0.1
+ *
+ */
+package jaicore.ml.core.exception;

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IBatchLearner.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IBatchLearner.java
@@ -1,0 +1,26 @@
+package jaicore.ml.core.predictivemodel;
+
+import jaicore.ml.core.dataset.IDataset;
+import jaicore.ml.core.exception.TrainingException;
+
+/**
+ * The {@link IBatchLearner} models a learning algorithm which works in a batch fashion, i.e. takes a whole {@link IDataset} as training input. It can be trained based on an {@link IDataset} in order
+ * to make predictions.
+ * 
+ * @author Alexander Hetzer
+ *
+ * @param <TARGET>
+ *            The type of the target that this {@link IBatchLearner} predicts.
+ */
+public interface IBatchLearner<TARGET> extends IPredictiveModel<TARGET> {
+
+	/**
+	 * Trains this {@link IBatchLearner} using the given {@link IDataset}.
+	 * 
+	 * @param dataset
+	 *            The {@link IDataset} which should be used for the training.
+	 * @throws TrainingException
+	 *             If something fails during the training process.
+	 */
+	public void train(IDataset dataset) throws TrainingException;
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IOnlineLearner.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IOnlineLearner.java
@@ -1,0 +1,37 @@
+package jaicore.ml.core.predictivemodel;
+
+import java.util.Set;
+
+import jaicore.ml.core.dataset.IInstance;
+import jaicore.ml.core.exception.TrainingException;
+
+/**
+ * The {@link IOnlineLearner} models a learning algorithm which works in an online fashion, i.e. takes either a single {@link IInstance} or a {@link Set} thereof as training input.
+ * 
+ * @author Alexander Hetzer
+ *
+ * @param <TARGET>
+ *            The type of the target that this {@link IOnlineLearner} predicts.
+ */
+public interface IOnlineLearner<TARGET> extends IBatchLearner<TARGET> {
+
+	/**
+	 * Updates this {@link IOnlineLearner} based on the given {@link Set} of {@link IInstance}s.
+	 * 
+	 * @param instances
+	 *            The {@link Set} of {@link IInstance}s the update should be based on.
+	 * @throws TrainingException
+	 *             If something fails during the update process.
+	 */
+	public void update(Set<IInstance> instances) throws TrainingException;
+
+	/**
+	 * Updates this {@link IOnlineLearner} based on the given {@link IInstance}.
+	 * 
+	 * @param instance
+	 *            The {@link IInstance} the update should be based on.
+	 * @throws TrainingException
+	 *             If something fails during the update process.
+	 */
+	public void update(IInstance instance) throws TrainingException;
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IPredictiveModel.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IPredictiveModel.java
@@ -1,0 +1,57 @@
+package jaicore.ml.core.predictivemodel;
+
+import java.util.List;
+
+import jaicore.ml.core.dataset.IDataset;
+import jaicore.ml.core.dataset.IInstance;
+import jaicore.ml.core.exception.ConfigurationException;
+import jaicore.ml.core.exception.PredictionException;
+
+/**
+ * The {@link IPredictiveModel} corresponds to a model which can be used to make predictions based on given {@link IInstance}es.
+ * 
+ * @author Alexander Hetzer
+ *
+ * @param <TARGET>
+ *            The type of the target that this {@link IPredictiveModel} predicts.
+ */
+public interface IPredictiveModel<TARGET> {
+
+	/**
+	 * Performs a prediction based on the given {@link IInstance} and returns the result.
+	 * 
+	 * @param instance
+	 *            The {@link IInstance} for which a prediction should be made.
+	 * @return The result of the prediction.
+	 * @throws PredictionException
+	 *             If something fails during the prediction process.
+	 */
+	public TARGET predict(IInstance instance) throws PredictionException;
+
+	/**
+	 * Performs multiple predictions based on the {@link IInstance}s contained in the given {@link IDataset}s and returns the result.
+	 * 
+	 * @param dataset
+	 *            The {@link IDataset} for which predictions should be made.
+	 * @return The result of the predictions.
+	 * @throws PredictionException
+	 *             If something fails during the prediction process.
+	 */
+	public List<TARGET> predict(IDataset dataset) throws PredictionException;
+
+	/**
+	 * Returns the {@link IPredictiveModelConfiguration} of this model.
+	 * 
+	 * @return The {@link IPredictiveModelConfiguration} of this model.
+	 */
+	public IPredictiveModelConfiguration getConfiguration();
+
+	/**
+	 * Sets the {@link IPredictiveModelConfiguration} of this model to the given one.
+	 * 
+	 * @throws ConfigurationException
+	 *             If something fails during the configuration process.
+	 */
+	public void setConfiguration(IPredictiveModelConfiguration configuration) throws ConfigurationException;
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IPredictiveModelConfiguration.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/IPredictiveModelConfiguration.java
@@ -1,0 +1,11 @@
+package jaicore.ml.core.predictivemodel;
+
+/**
+ * The {@link IPredictiveModelConfiguration} models a configuration of an {@link IPredictiveModel}.
+ * 
+ * @author Alexander Hetzer
+ *
+ */
+public interface IPredictiveModelConfiguration {
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/package-info.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/core/predictivemodel/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains interfaces related to predictive models and learning algorithms.
+ * 
+ * @since 0.0.1
+ *
+ */
+package jaicore.ml.core.predictivemodel;


### PR DESCRIPTION
Added new machine learning interfaces which should serve as a base for
defining a custom ML Java framework.

The IPredictiveModel serves as a top interface offering functionality
for prediction processes. Lying beneath, the IBatchLearner offers
functionality of batch learning, followed by the IOnlineLearner which
offers functionality related to online learning.

In order to give a user the opportunity to properly catch exceptions
caused by methods contained in these interfaces, several new exceptions
were introduced together with base classes where each exception defined
in jaicore-ml should be based on. This simplifies the task of catching
all exceptions emitted by a certain module (except for Java default
exceptions).