### PR TITLE
Intermediate Result Cache

### DIFF
--- a/JAICore/jaicore-ml/src/jaicore/ml/WekaUtil.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/WekaUtil.java
@@ -767,7 +767,7 @@ public class WekaUtil {
 		/* compute instances per class */
 		Map<String, Instances> classWiseSeparation = getInstancesPerClass(shuffledData);
 
-		Map<String, Integer> classCapacities = new HashMap<>();
+		Map<String, Integer> classCapacities = new HashMap<>(classWiseSeparation.size());
 		for (String c : classWiseSeparation.keySet()) {
 			classCapacities.put(c, classWiseSeparation.get(c).size());
 		}
@@ -805,12 +805,12 @@ public class WekaUtil {
 
 	
 	/**
-	 * Creates a StratifiedSplit for a given {@link ReproducibleInstances} Object. THe History will be updated to track the split.
+	 * Creates a stratified split for a given {@link ReproducibleInstances} Object. The history will be updated to track the split.
 	 * 
 	 * @param data - Input data
 	 * @param rand - random used to get a seed, which can be used and saved
 	 * @param portions - ratios to split
-	 * @return a List of {@link ReproducibleInstances}. For each of them the history will be updated to track the split
+	 * @return a list of {@link ReproducibleInstances}. For each of them the history will be updated to track the split
 	 */
 	public static List<ReproducibleInstances> getStratifiedSplit(final ReproducibleInstances data, final Random rand, final double... portions) {
 		return getStratifiedSplit(data, rand.nextLong(), portions);
@@ -844,7 +844,7 @@ public class WekaUtil {
 		/* compute instances per class */
 		Map<String, Instances> classWiseSeparation = getInstancesPerClass(shuffledData);
 
-		Map<String, Integer> classCapacities = new HashMap<>();
+		Map<String, Integer> classCapacities = new HashMap<>(classWiseSeparation.size());
 		for (String c : classWiseSeparation.keySet()) {
 			classCapacities.put(c, classWiseSeparation.get(c).size());
 		}
@@ -879,7 +879,7 @@ public class WekaUtil {
 		}
 		assert instances.stream().mapToInt(l -> l.size()).sum() == data.size() : "The number of instances in the folds does not equal the number of instances in the original dataset";
 		
-		/* update ReproducibleInstanes History */
+		/* update ReproducibleInstanes history */
 		String ratiosAsString = Arrays.toString(portions);
 		for(int i = 0; i < instances.size(); i++) {
 			instances.get(i).addInstruction(new SplitInstruction(ratiosAsString, seed, i));

--- a/JAICore/jaicore-ml/src/jaicore/ml/WekaUtil.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/WekaUtil.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -31,6 +32,8 @@ import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
 
+import jaicore.ml.cache.ReproducibleInstances;
+import jaicore.ml.cache.SplitInstruction;
 import jaicore.ml.core.SimpleInstanceImpl;
 import jaicore.ml.core.SimpleInstancesImpl;
 import jaicore.ml.core.SimpleLabeledInstanceImpl;
@@ -624,7 +627,7 @@ public class WekaUtil {
 		for (String className : numberOfInstancesPerClass.keySet()) {
 			numberOfInstancesPerClassAndFold.put(className, new HashMap<>());
 			for (int foldId = 0; foldId < portions.length; foldId++) {
-				numberOfInstancesPerClassAndFold.get(className).put(foldId, (int) Math.ceil(numberOfInstancesPerClass.get(className) * portions[foldId]));
+				numberOfInstancesPerClassAndFold.get(className).put(foldId, ((int) Math.ceil(numberOfInstancesPerClass.get(className) * portions[foldId])) + 1 );
 			}
 		}
 
@@ -734,8 +737,18 @@ public class WekaUtil {
 		return an;
 	}
 
-	public static List<Instances> getStratifiedSplit(final Instances data, final Random rand, final double... portions) {
-
+	
+	public static List<Instances> getStratifiedSplit(final Instances data, final long seed, final double... portions) {
+		// if data should be reproducible use other method. 
+		if(data instanceof ReproducibleInstances) {
+			List<ReproducibleInstances> reproducibleInstancesResult = getStratifiedSplit((ReproducibleInstances)data, seed, portions);
+			ArrayList<Instances> result = new ArrayList<>(reproducibleInstancesResult.size());
+			for (int i = 0; i < reproducibleInstancesResult.size(); i++) {
+				result.add(reproducibleInstancesResult.get(i));
+			}
+			return result; 
+		}
+		Random rand = new Random(seed);
 		/* check that portions sum up to s.th. smaller than 1 */
 		double sum = 0;
 		for (double p : portions) {
@@ -790,6 +803,92 @@ public class WekaUtil {
 		return instances;
 	}
 
+	
+	/**
+	 * Creates a StratifiedSplit for a given {@link ReproducibleInstances} Object. THe History will be updated to track the split.
+	 * 
+	 * @param data - Input data
+	 * @param rand - random used to get a seed, which can be used and saved
+	 * @param portions - ratios to split
+	 * @return a List of {@link ReproducibleInstances}. For each of them the history will be updated to track the split
+	 */
+	public static List<ReproducibleInstances> getStratifiedSplit(final ReproducibleInstances data, final Random rand, final double... portions) {
+		return getStratifiedSplit(data, rand.nextLong(), portions);
+	}
+	
+	/**
+	 * Creates a StratifiedSplit for a given {@link ReproducibleInstances} Object. THe History will be updated to track the split.
+	 * 
+	 * @param data - Input data
+	 * @param seed - random seed
+	 * @param portions - ratios to split
+	 * @return a List of {@link ReproducibleInstances}. For each of them the history will be updated to track the split
+	 */
+	public static List<ReproducibleInstances> getStratifiedSplit(final ReproducibleInstances data, final long seed, final double... portions) {
+		Random rand = new Random(seed);
+		/* check that portions sum up to s.th. smaller than 1 */
+		double sum = 0;
+		for (double p : portions) {
+			sum += p;
+		}
+		if (sum > 1) {
+			throw new IllegalArgumentException("Portions must sum up to at most 1.");
+		}
+
+		Instances shuffledData = new Instances(data);
+		shuffledData.randomize(rand);
+		List<ReproducibleInstances> instances = new ArrayList<>();
+		ReproducibleInstances emptyInstances = new ReproducibleInstances(data);
+		emptyInstances.clear(); // leaves History untouched
+		
+		/* compute instances per class */
+		Map<String, Instances> classWiseSeparation = getInstancesPerClass(shuffledData);
+
+		Map<String, Integer> classCapacities = new HashMap<>();
+		for (String c : classWiseSeparation.keySet()) {
+			classCapacities.put(c, classWiseSeparation.get(c).size());
+		}
+
+		/* first assign one item of each class to each fold */
+		for (int i = 0; i <= portions.length; i++) {
+			ReproducibleInstances instancesForSplit = new ReproducibleInstances(emptyInstances); // Will have the same history as data but is empty
+			
+			for (String c : classWiseSeparation.keySet()) {
+				Instances availableInstances = classWiseSeparation.get(c);
+				if (!availableInstances.isEmpty()) {
+					instancesForSplit.add(availableInstances.get(0));
+					availableInstances.remove(0);
+				}
+			}
+			instances.add(instancesForSplit);
+		}
+
+		/* now distribute remaining instances over the folds */
+		for (int i = 0; i <= portions.length; i++) {
+			double portion = i < portions.length ? portions[i] : 1 - sum;
+			ReproducibleInstances instancesForSplit = instances.get(i);
+			for (String c : classWiseSeparation.keySet()) {
+				Instances availableInstances = classWiseSeparation.get(c);
+				int items = (int) Math.min(availableInstances.size(), Math.ceil(portion * classCapacities.get(c)));
+				for (int j = 0; j < items; j++) {
+					instancesForSplit.add(availableInstances.get(0));
+					availableInstances.remove(0);
+				}
+			}
+			instancesForSplit.randomize(rand);
+		}
+		assert instances.stream().mapToInt(l -> l.size()).sum() == data.size() : "The number of instances in the folds does not equal the number of instances in the original dataset";
+		
+		/* update ReproducibleInstanes History */
+		String ratiosAsString = Arrays.toString(portions);
+		for(int i = 0; i < instances.size(); i++) {
+			instances.get(i).addInstruction(new SplitInstruction(ratiosAsString, seed, i));
+		}
+		return instances;
+	}
+
+	
+	
 	public static List<File> getDatasetsInFolder(final File folder) throws IOException {
 		List<File> files = new ArrayList<>();
 		try (Stream<Path> paths = Files.walk(folder.toPath())) {
@@ -975,11 +1074,7 @@ public class WekaUtil {
 	}
 	
 	public static List<Double> getClassesAsList(Instances inst) {
-		List<Double> vec = new ArrayList<>();
-		for (Instance i : inst) {
-			vec.add(i.classValue());
-		}
-		return vec;
+		return inst.stream().map(Instance::classValue).collect(Collectors.toList());
 	}
 
 	public static String instancesToJsonString(final Instances data) {

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/Instruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/Instruction.java
@@ -1,0 +1,53 @@
+package jaicore.ml.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Instruction class that can be converted into json. Used by {@link ReproducibleInstances}.
+ * 
+ * @author jnowack
+ *
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "command", visible = true)
+@JsonSubTypes({ 
+	  @Type(value = LoadDataSetInstruction.class, name = "loadDataset"),
+	  @Type(value = SplitInstruction.class, name = "split")
+	})
+public abstract class Instruction {
+
+	public Instruction() {
+		inputs = new HashMap<String, String>();
+	}
+	
+	@JsonProperty
+	String command = "noCommand";
+	
+	@JsonProperty
+	Map<String, String> inputs = new HashMap<>();
+	
+	
+	public String getCommand() {
+		return command;
+	}
+	
+	public void setCommand(String command) {
+		this.command = command;
+	}
+	
+	public Map<String, String> getInputs() {
+		return inputs;
+	}
+	
+	public void setInputs(Map<String, String> inputs) {
+		this.inputs = inputs;
+	}
+	
+	
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/Instruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/Instruction.java
@@ -10,7 +10,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * Instruction class that can be converted into json. Used by {@link ReproducibleInstances}.
+ * Instruction class that can be converted into json. Used by {@link ReproducibleInstances}. The instructions are used to store information about the dataset origin and the splits done.
+ * Supported are {@link LoadDataSetInstruction} and {@link SplitInstruction} at the moment. <br>
+ * 
+ * An instruction is identified by a command name, that specifies the type of instruction and a list if input parameters.
  * 
  * @author jnowack
  *
@@ -32,19 +35,31 @@ public abstract class Instruction {
 	@JsonProperty
 	Map<String, String> inputs = new HashMap<>();
 	
-	
+	/**Sets command name that specifies the type of instruction represented by the object. Every instructions has a unique command name.
+	 * @return the name of the command used to identify it.
+	 */
 	public String getCommand() {
 		return command;
 	}
 	
+	/** 
+	 * Gets command name that specifies the type of instruction represented by the object. Every instructions needs a unique command name.  
+	 * @param command name of the command
+	 */
 	public void setCommand(String command) {
 		this.command = command;
 	}
 	
+	/** Inputs are parameters of the instruction. These inputs are used to reproduce the effects of this instruction.
+	 * @return the list of input arguments for the instruction
+	 */
 	public Map<String, String> getInputs() {
 		return inputs;
 	}
 	
+	/**Sets the input parameters that will be used to reproduce the effects done by this instruction.
+	 * @param inputs map of inputs as pairs of to Strings.
+	 */
 	public void setInputs(Map<String, String> inputs) {
 		this.inputs = inputs;
 	}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/LoadDataSetInstruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/LoadDataSetInstruction.java
@@ -10,12 +10,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class LoadDataSetInstruction extends Instruction{
 	
+	/** Constant String to Identify this Instruction*/
+	public static final String COMMAND_NAME = "loadDataset";
+	
 	/**
+	 * Constructor to create an instruction for loading a dataset that can be converted to json.
+	 * 
 	 * @param provider used to identify origin of the dataset
 	 * @param id used to identify dataset
 	 */
 	public LoadDataSetInstruction(@JsonProperty("provider") String provider, @JsonProperty("id") String id) {
-		command = "loadDataset";
+		command = COMMAND_NAME;
 		inputs.put("provider", provider);
 		inputs.put("id", id);
 	}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/LoadDataSetInstruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/LoadDataSetInstruction.java
@@ -1,0 +1,23 @@
+package jaicore.ml.cache;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Instruction for dataset loading, provider and id are used to identify the data set. See {@link ReproducibleInstances} for more information.
+ * 
+ * @author jnowack
+ *
+ */
+public class LoadDataSetInstruction extends Instruction{
+	
+	/**
+	 * @param provider used to identify origin of the dataset
+	 * @param id used to identify dataset
+	 */
+	public LoadDataSetInstruction(@JsonProperty("provider") String provider, @JsonProperty("id") String id) {
+		command = "loadDataset";
+		inputs.put("provider", provider);
+		inputs.put("id", id);
+	}
+	
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/ReproducibleInstances.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/ReproducibleInstances.java
@@ -1,0 +1,175 @@
+package jaicore.ml.cache;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import jaicore.ml.WekaUtil;
+import jaicore.ml.openml.OpenMLHelper;
+import weka.core.Instances;
+
+/**
+ * New Instances class to track splits and data origin.
+ * 
+ * @author jnowack
+ * @author mirko
+ * @author jonas
+ *
+ */
+public class ReproducibleInstances extends Instances {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 4318807226111536282L;
+	private List<Instruction> history = new LinkedList<>();
+	private boolean cacheStorage = true;
+	private boolean cacheLookup = true;
+	
+	private ReproducibleInstances(Instances dataset) {
+		super(dataset);
+	}
+	
+	/**
+	 * Creates a {@link ReproducibleInstances} Object based on the given History. Instructions that no not modify the Instances will be ignored (No evaluation will be done). 
+	 * 
+	 * @param history - List of INstructions used to create the original Instances
+	 * @param apiKey - apiKey in case openml.org is used
+	 * @return new {@link ReproducibleInstances} object
+	 * @throws IOException 
+	 * @throws  
+	 */
+	public static ReproducibleInstances fromHistory(List<Instruction> history, String apiKey) throws IOException {
+		ReproducibleInstances instances = null;
+		for (int i = 0; i < history.size(); i++) {
+			Instruction inst = history.get(i);
+			switch (inst.command) {
+			case "loadDataset":
+				// load openml or local dataset
+				if(inst.inputs.get("provider").equals("openml.org")) {
+					instances = fromOpenML(inst.inputs.get("id"), apiKey);
+				}
+				else if(inst.inputs.get("provider").startsWith("local")) {
+					instances = fromARFF(inst.inputs.get("id"), inst.inputs.get("provider").split("\\.")[1]);
+				}
+				break;
+			case "split":
+				// create split
+				String[] ratiosAsStrings = inst.getInputs().get("ratios").split(",");
+				double[] ratios = new double[ratiosAsStrings.length];
+				for (int j = 0; j < ratiosAsStrings.length; j++) {
+					ratios[j] = Double.parseDouble(ratiosAsStrings[j].trim().substring(1, ratiosAsStrings[j].length()-1));
+				}
+				instances = WekaUtil.getStratifiedSplit(instances, Long.parseLong(inst.inputs.get("seed")), ratios).get( Integer.parseInt(inst.getInputs().get("outIndex")));
+				break;
+			default:
+				break;
+			}
+		}
+		return instances;
+	}
+	
+
+	
+	public ReproducibleInstances(ReproducibleInstances dataset) {
+		super(dataset);
+		for (Iterator<Instruction> iterator = dataset.history.iterator(); iterator.hasNext();) {
+			Instruction i = iterator.next();
+			history.add(i);
+		}
+		cacheLookup = dataset.cacheLookup;
+		cacheStorage = dataset.cacheStorage;
+	}
+
+	/**
+	 * Creates a new {@link ReproducibleInstances} object. Data is loaded from
+	 * openml.org.
+	 * 
+	 * @param id     The id of the openml dataset
+	 * @param apiKey apikey to use
+	 * @return new {@link ReproducibleInstances} object
+	 * @throws NumberFormatException
+	 * @throws IOException
+	 */
+	public static ReproducibleInstances fromOpenML(String id, String apiKey) throws NumberFormatException, IOException {
+		OpenMLHelper.setApiKey(apiKey);
+		ReproducibleInstances result = new ReproducibleInstances(OpenMLHelper.getInstancesById(Integer.parseInt(id)));
+		result.history.add(new LoadDataSetInstruction("openml.org", id));
+		result.cacheLookup = true;
+		result.cacheStorage = true;
+		return result;
+	}
+
+	/**
+	 * Creates a new {@link ReproducibleInstances} object. Data is loaded from a
+	 * local arff file.
+	 * 
+	 * @param path path to the dataset
+	 * @param user We assume that the combination of user and path is unique
+	 * @return new {@link ReproducibleInstances} object
+	 * @throws IOException
+	 */
+	public static ReproducibleInstances fromARFF(String path, String user) throws IOException {
+		Instances data = new Instances(new FileReader(path)); // TODO mirko
+		data.setClassIndex(data.numAttributes() - 1);
+		ReproducibleInstances result = new ReproducibleInstances(data);
+		result.history.add(new LoadDataSetInstruction("local_" + user, path));
+		result.cacheLookup = true;
+		result.cacheStorage = true;
+		return result;
+	}
+
+	/**
+	 * returns the ordered lists of instructions or null if cache is not used
+	 * 
+	 * @return
+	 */
+	public List<Instruction> getInstructions() {
+		if(cacheLookup || cacheStorage) {
+			return history;
+		}
+		else {
+			return null;
+		}
+	}
+	
+	/**
+	 * Adds a new Instruction to the history of these Instances
+	 * 
+	 * @param i - new Instruction
+	 */
+	public void addInstruction(Instruction i) {
+		history.add(i);
+	}
+
+	/**
+	 * @return the cacheStorage
+	 */
+	public boolean isCacheStorage() {
+		return cacheStorage;
+	}
+
+	/**
+	 * @param cacheStorage the cacheStorage to set
+	 */
+	public void setCacheStorage(boolean cacheStorage) {
+		this.cacheStorage = cacheStorage;
+	}
+
+	/**
+	 * @return the cacheLookup
+	 */
+	public boolean isCacheLookup() {
+		return cacheLookup;
+	}
+
+	/**
+	 * @param cacheLookup the cacheLookup to set
+	 */
+	public void setCacheLookup(boolean cacheLookup) {
+		this.cacheLookup = cacheLookup;
+	}
+	
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/SplitInstruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/SplitInstruction.java
@@ -2,15 +2,22 @@ package jaicore.ml.cache;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jaicore.ml.WekaUtil;
+
 /**
- * Instruction to track a split.
+ * Instruction to track a split for a {@link ReproducibleInstances} object. Performns a stratified split from {@link WekaUtil} based on the given ratios and seed. The index gives the split to be used by the {@link ReproducibleInstances}.
  * 
  * @author jnowack
  *
  */
 public class SplitInstruction extends Instruction {
 
+	/** Constant string to identify this instruction. */
+	public static final String COMMAND_NAME = "split";
+	
 	/**
+	 * Constructor to create a split Instruction that can be converted into json.
+	 * 
 	 * @param ratios
 	 *            ratios for the split
 	 * @param seed
@@ -20,7 +27,7 @@ public class SplitInstruction extends Instruction {
 	 */
 	public SplitInstruction(@JsonProperty("ratios") String ratios, @JsonProperty("seed") long seed,
 			@JsonProperty("outIndex") int outIndex) {
-		command = "split";
+		command = COMMAND_NAME;
 		inputs.put("ratios", "" + ratios);
 		inputs.put("seed", "" + seed);
 		inputs.put("outIndex", "" + outIndex);

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/SplitInstruction.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/SplitInstruction.java
@@ -1,0 +1,29 @@
+package jaicore.ml.cache;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Instruction to track a split.
+ * 
+ * @author jnowack
+ *
+ */
+public class SplitInstruction extends Instruction {
+
+	/**
+	 * @param ratios
+	 *            ratios for the split
+	 * @param seed
+	 *            random seed
+	 * @param outIndex
+	 *            index of the portion to use in the following
+	 */
+	public SplitInstruction(@JsonProperty("ratios") String ratios, @JsonProperty("seed") long seed,
+			@JsonProperty("outIndex") int outIndex) {
+		command = "split";
+		inputs.put("ratios", "" + ratios);
+		inputs.put("seed", "" + seed);
+		inputs.put("outIndex", "" + outIndex);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/cache/package-info.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/cache/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Package to create {@link jaicore.ml.cache.ReproducibleInstances} which can be stored and recreated if needed.
+ * 
+ * @author Joshua
+ * @author Mirko
+ * @author Jonas
+ *
+ */
+package jaicore.ml.cache;

--- a/JAICore/jaicore-ml/src/jaicore/ml/classification/multiclass/reduction/PipelineOptimizer.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/classification/multiclass/reduction/PipelineOptimizer.java
@@ -30,15 +30,14 @@ public class PipelineOptimizer {
 			System.out.println(i + ": " + inst.classAttribute().value(i));
 		
 		for (int j = 0; j < 1; j++) {
-			Random rand = new Random(j);
-			List<Instances> split = WekaUtil.getStratifiedSplit(inst, rand, .6f);
+			List<Instances> split = WekaUtil.getStratifiedSplit(inst, j, .6f);
 			
 			System.out.print("Running base learner ...");
 //			Classifier rf = AbstractClassifier.forName(classifierName, null);
 			mcc.buildClassifier(split.get(0));
 			System.out.println("done. Accuracy: " + getAccuracy(mcc, split.get(1)) + "%");
 			
-			Classifier c = new ReductionOptimizer(rand);
+			Classifier c = new ReductionOptimizer(j);
 			
 //			System.out.print("Train ... ");
 			c.buildClassifier(split.get(0));

--- a/JAICore/jaicore-ml/src/jaicore/ml/classification/multiclass/reduction/reducer/ReductionOptimizer.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/classification/multiclass/reduction/reducer/ReductionOptimizer.java
@@ -32,20 +32,20 @@ import weka.core.Instances;
 
 public class ReductionOptimizer implements Classifier {
 
-	private final Random rand;
+	private final long seed;
 	private MCTreeNode root;
 
-	public ReductionOptimizer(Random rand) {
+	public ReductionOptimizer(long seed) {
 		super();
-		this.rand = rand;
+		this.seed = seed;
 	}
 
 	@Override
 	public void buildClassifier(Instances data) throws Exception {
-		List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, rand, .6f);
+		List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, seed, .6f);
 		Instances train = dataSplit.get(0);
 		Instances validate = dataSplit.get(1);
-		BestFirstEpsilon<RestProblem, Decision, Double> search = new BestFirstEpsilon<RestProblem, Decision, Double>(new GeneralEvaluatedTraversalTree<>(new ReductionGraphGenerator(rand, train), n -> getLossForClassifier(getTreeFromSolution(n.externalPath(), data, false), data) * 1.0), n -> n.path().size() * -1.0
+		BestFirstEpsilon<RestProblem, Decision, Double> search = new BestFirstEpsilon<RestProblem, Decision, Double>(new GeneralEvaluatedTraversalTree<>(new ReductionGraphGenerator(new Random(seed), train), n -> getLossForClassifier(getTreeFromSolution(n.externalPath(), data, false), data) * 1.0), n -> n.path().size() * -1.0
 		, 0.1, false);
 
 		VisualizationWindow<Node<RestProblem, Double>,Decision> window = new VisualizationWindow<>(search);
@@ -122,7 +122,7 @@ public class ReductionOptimizer implements Classifier {
 			try {
 				DescriptiveStatistics stats = new DescriptiveStatistics();
 				for (int i = 0; i < 2; i++) {
-					List<Instances> split = (WekaUtil.getStratifiedSplit(data, rand, .6f));
+					List<Instances> split = (WekaUtil.getStratifiedSplit(data, seed + i, .6f));
 					tree.buildClassifier(split.get(0));
 
 					Evaluation eval = new Evaluation(data);

--- a/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/AbstractEvaluatorMeasureBridge.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/AbstractEvaluatorMeasureBridge.java
@@ -4,8 +4,10 @@ import jaicore.ml.core.evaluation.measure.IMeasure;
 import weka.classifiers.Classifier;
 import weka.core.Instances;
 /**
- * An abstract evaluator measure-bridge 
- * @author elppa
+ * Connection between an Evaluator (e.g. MCC) and a loss Function. Able to evaluate instances based on training data and validation data.
+ * This bridge may modify this process, for example by using a cache.
+ *  
+ * @author mirko
  *
  * @param <I> the input type
  * @param <O> the output type

--- a/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/AbstractEvaluatorMeasureBridge.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/AbstractEvaluatorMeasureBridge.java
@@ -1,0 +1,28 @@
+package jaicore.ml.evaluation.evaluators.weka;
+
+import jaicore.ml.core.evaluation.measure.IMeasure;
+import weka.classifiers.Classifier;
+import weka.core.Instances;
+/**
+ * An abstract evaluator measure-bridge 
+ * @author elppa
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ */
+public abstract class AbstractEvaluatorMeasureBridge <I, O>{
+	
+	
+	protected final IMeasure<I, O> basicEvaluator;
+
+	
+	public AbstractEvaluatorMeasureBridge(final IMeasure<I, O> basicEvaluator) {
+		this.basicEvaluator = basicEvaluator;
+	}
+	
+	public abstract O evaluateSplit(final Classifier pl, Instances trainingData, Instances validationData) throws Exception;
+
+	public IMeasure<I, O> getBasicEvaluator(){
+		return basicEvaluator;
+	}
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SimpleEvaluatorMeasureBridge.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SimpleEvaluatorMeasureBridge.java
@@ -1,0 +1,36 @@
+package jaicore.ml.evaluation.evaluators.weka;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jaicore.ml.WekaUtil;
+import jaicore.ml.core.evaluation.measure.IMeasure;
+import jaicore.ml.evaluation.IInstancesClassifier;
+import weka.classifiers.Classifier;
+import weka.core.Instance;
+import weka.core.Instances;
+
+public class SimpleEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge<Double, Double>{
+
+	public SimpleEvaluatorMeasureBridge(IMeasure<Double, Double> basicEvaluator) {
+		super(basicEvaluator);
+	}
+
+	@Override
+	public Double evaluateSplit(Classifier pl, Instances trainingData, Instances validationData) throws Exception {
+		List<Double> actual = WekaUtil.getClassesAsList(validationData);
+		List<Double> predicted = new ArrayList<>();
+		pl.buildClassifier(trainingData);
+		if (pl instanceof IInstancesClassifier) {
+			for (double prediction : ((IInstancesClassifier) pl).classifyInstances(validationData)) {
+				predicted.add(prediction);
+			}
+		} else {
+			for (Instance inst : validationData) {
+				predicted.add(pl.classifyInstance(inst));
+			}
+		}
+		return this.basicEvaluator.calculateAvgMeasure(actual, predicted);
+	}
+
+}

--- a/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SimpleEvaluatorMeasureBridge.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SimpleEvaluatorMeasureBridge.java
@@ -10,6 +10,12 @@ import weka.classifiers.Classifier;
 import weka.core.Instance;
 import weka.core.Instances;
 
+/**
+ * Basic implementation of the {@link AbstractEvaluatorMeasureBridge}. Uses the given loss function to compute loss on the given data. No extra steps are performed.
+ * 
+ * @author jnowack
+ *
+ */
 public class SimpleEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge<Double, Double>{
 
 	public SimpleEvaluatorMeasureBridge(IMeasure<Double, Double> basicEvaluator) {
@@ -17,17 +23,17 @@ public class SimpleEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge
 	}
 
 	@Override
-	public Double evaluateSplit(Classifier pl, Instances trainingData, Instances validationData) throws Exception {
+	public Double evaluateSplit(Classifier classifier, Instances trainingData, Instances validationData) throws Exception {
 		List<Double> actual = WekaUtil.getClassesAsList(validationData);
 		List<Double> predicted = new ArrayList<>();
-		pl.buildClassifier(trainingData);
-		if (pl instanceof IInstancesClassifier) {
-			for (double prediction : ((IInstancesClassifier) pl).classifyInstances(validationData)) {
+		classifier.buildClassifier(trainingData);
+		if (classifier instanceof IInstancesClassifier) {
+			for (double prediction : ((IInstancesClassifier) classifier).classifyInstances(validationData)) {
 				predicted.add(prediction);
 			}
 		} else {
 			for (Instance inst : validationData) {
-				predicted.add(pl.classifyInstance(inst));
+				predicted.add(classifier.classifyInstance(inst));
 			}
 		}
 		return this.basicEvaluator.calculateAvgMeasure(actual, predicted);

--- a/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SingleRandomSplitClassifierEvaluator.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/evaluation/evaluators/weka/SingleRandomSplitClassifierEvaluator.java
@@ -1,7 +1,6 @@
 package jaicore.ml.evaluation.evaluators.weka;
 
 import java.util.List;
-import java.util.Random;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +24,7 @@ public class SingleRandomSplitClassifierEvaluator implements IClassifierEvaluato
 
 	@Override
 	public Double evaluate(Classifier c) throws InterruptedException {
-		List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(seed >= 0 ? seed : System.currentTimeMillis()), trainingPortion);
+		List<Instances> split = WekaUtil.getStratifiedSplit(data, seed >= 0 ? seed : System.currentTimeMillis(), trainingPortion);
 		try {
 			c.buildClassifier(split.get(0));
 			Evaluation eval = new Evaluation(split.get(0));

--- a/JAICore/jaicore-ml/src/jaicore/ml/openml/OpenMLHelper.java
+++ b/JAICore/jaicore-ml/src/jaicore/ml/openml/OpenMLHelper.java
@@ -61,7 +61,7 @@ public class OpenMLHelper {
 	 * 
 	 * @param dataId
 	 * @return
-	 * @throws IOException
+	 * @throws IOException if something goes wrong while loading Instances from openml
 	 */
 	public static Instances getInstancesById(int dataId) throws IOException {
 		Instances dataset = null;

--- a/JAICore/jaicore-ml/test/jaicore/ml/MCTreeNodeReDTest.java
+++ b/JAICore/jaicore-ml/test/jaicore/ml/MCTreeNodeReDTest.java
@@ -25,7 +25,7 @@ public class MCTreeNodeReDTest {
 		data.setClassIndex(data.numAttributes() - 1);
 
 		for (int s = 0; s < 10; s++) {
-			List<Instances> stratifiedSplit = WekaUtil.getStratifiedSplit(data, new Random(s), 0.7);
+			List<Instances> stratifiedSplit = WekaUtil.getStratifiedSplit(data, s, 0.7);
 
 			List<String> classValues = new LinkedList<>();
 			for (int i = 0; i < data.numClasses(); i++) {

--- a/JAICore/jaicore-ml/test/jaicore/ml/core/WekaConversionTest.java
+++ b/JAICore/jaicore-ml/test/jaicore/ml/core/WekaConversionTest.java
@@ -177,7 +177,7 @@ public class WekaConversionTest {
 	public void checkClassifierPerformance() throws Exception {
 		Instances data = new Instances(new BufferedReader(new FileReader(folder + File.separator + "vowel.arff")));
 		data.setClassIndex(data.numAttributes() - 1);
-		List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(System.currentTimeMillis()), .9f);
+		List<Instances> split = WekaUtil.getStratifiedSplit(data, System.currentTimeMillis(), .9f);
 		Instances instOrig = split.get(0);
 		Instances instTranslated = WekaUtil.fromJAICoreInstances(WekaUtil.toJAICoreLabeledInstances(instOrig));
 		Instances instTest = split.get(1);

--- a/softwareconfiguration/hasco/src/hasco/model/Component.java
+++ b/softwareconfiguration/hasco/src/hasco/model/Component.java
@@ -5,17 +5,23 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import jaicore.basic.sets.PartialOrderedSet;
 
+@JsonPropertyOrder({ "name", "parameters", "dependencies", "providedInterfaces", "requiredInterfaces" })
 public class Component {
 	private final String name;
-	private final Collection<String> providedInterfaces = new ArrayList<>();
-	private final LinkedHashMap<String, String> requiredInterfaces = new LinkedHashMap<>();
-	private final PartialOrderedSet<Parameter> parameters = new PartialOrderedSet<>();
-	private final Collection<Dependency> dependencies = new ArrayList<>();
+	private Collection<String> providedInterfaces = new ArrayList<>();
+	private LinkedHashMap<String, String> requiredInterfaces = new LinkedHashMap<>();
+	private PartialOrderedSet<Parameter> parameters = new PartialOrderedSet<>();
+	private Collection<Dependency> dependencies = new ArrayList<>();
 
 	public Component(final String name) {
 		super();
@@ -23,15 +29,32 @@ public class Component {
 		this.getProvidedInterfaces().add(this.name);
 	}
 
-	public Component(final String name, final TreeMap<String, String> requiredInterfaces, final Collection<String> providedInterfaces, final List<Parameter> parameters, final Collection<Dependency> dependencies) {
+	// Json constructor
+	@JsonCreator
+	public Component(@JsonProperty("name") final String name,
+			@JsonProperty("providedInterfaces") Collection<String> providedInterfaces,
+			@JsonProperty("requiredInterfaces") List<Map<String, String>> requiredInterfaces,
+			@JsonProperty("parameters") PartialOrderedSet<Parameter> parameters,
+			@JsonProperty("dependencies") List<Dependency> dependencies) {
+		super();
+		this.name = name;
+		this.providedInterfaces = providedInterfaces;
+		this.requiredInterfaces = new LinkedHashMap<>();
+		requiredInterfaces.iterator().next().forEach(this.requiredInterfaces::put);
+		this.parameters = parameters;
+		this.dependencies = dependencies;
+	}
+
+	public Component(final String name, final TreeMap<String, String> requiredInterfaces,
+			final Collection<String> providedInterfaces, final List<Parameter> parameters,
+			final Collection<Dependency> dependencies) {
 		this(name);
 		this.requiredInterfaces.putAll(requiredInterfaces);
 		this.providedInterfaces.addAll(providedInterfaces);
 		if (!this.providedInterfaces.contains(name)) {
 			this.providedInterfaces.add(name);
 		}
-
-		parameters.forEach(param -> this.addParameter(param));
+		parameters.forEach(this::addParameter);
 		this.dependencies.addAll(dependencies);
 	}
 
@@ -54,7 +77,8 @@ public class Component {
 	public Parameter getParameterWithName(final String paramName) {
 		Optional<Parameter> param = this.parameters.stream().filter(p -> p.getName().equals(paramName)).findFirst();
 		if (!param.isPresent()) {
-			throw new IllegalArgumentException("Component " + this.name + " has no parameter with name \"" + paramName + "\"");
+			throw new IllegalArgumentException(
+					"Component " + this.name + " has no parameter with name \"" + paramName + "\"");
 		}
 		return param.get();
 	}
@@ -68,13 +92,17 @@ public class Component {
 	}
 
 	public void addParameter(final Parameter param) {
-		assert !this.parameters.stream().filter(p -> p.getName().equals(param.getName())).findAny().isPresent() : "Component " + this.name + " already has parameter with name " + param.getName();
+		assert !this.parameters.stream().filter(p -> p.getName().equals(param.getName())).findAny()
+				.isPresent() : "Component " + this.name + " already has parameter with name " + param.getName();
 		this.parameters.add(param);
 	}
 
 	public void addDependency(final Dependency dependency) {
 
-		/* check whether this dependency is coherent with the current partial order on the parameters */
+		/*
+		 * check whether this dependency is coherent with the current partial order on
+		 * the parameters
+		 */
 		Collection<Parameter> paramsInPremise = new HashSet<>();
 		dependency.getPremise().forEach(c -> c.forEach(i -> paramsInPremise.add(i.getX())));
 		Collection<Parameter> paramsInConclusion = new HashSet<>();

--- a/softwareconfiguration/hasco/src/hasco/model/ComponentInstance.java
+++ b/softwareconfiguration/hasco/src/hasco/model/ComponentInstance.java
@@ -5,21 +5,32 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import jaicore.basic.sets.SetUtil;
 
 /**
- * For a given component, a composition defines all parameter values and the required interfaces (recursively)
+ * For a given component, a composition defines all parameter values and the
+ * required interfaces (recursively)
  *
  * @author fmohr
  *
  */
+@JsonPropertyOrder(alphabetic=true)
 public class ComponentInstance {
 	private final Component component;
 	private final Map<String, String> parameterValues;
-	/** The satisfactionOfRequiredInterfaces map maps from Interface IDs to ComopnentInstances */
+	/**
+	 * The satisfactionOfRequiredInterfaces map maps from Interface IDs to
+	 * ComopnentInstances
+	 */
 	private final Map<String, ComponentInstance> satisfactionOfRequiredInterfaces;
 
-	public ComponentInstance(final Component component, final Map<String, String> parameterValues, final Map<String, ComponentInstance> satisfactionOfRequiredInterfaces) {
+	public ComponentInstance(@JsonProperty("component") final Component component,
+			@JsonProperty("parameterValues") final Map<String, String> parameterValues,
+			@JsonProperty("satisfactionOfRequiredInterfaces") final Map<String, ComponentInstance> satisfactionOfRequiredInterfaces) {
 		super();
 		this.component = component;
 		this.parameterValues = parameterValues;
@@ -33,27 +44,29 @@ public class ComponentInstance {
 	public Map<String, String> getParameterValues() {
 		return this.parameterValues;
 	}
-	
+
 	public Collection<Parameter> getParametersThatHaveBeenSetExplicitly() {
 		if (parameterValues == null)
 			return new ArrayList<>();
-		return getComponent().getParameters().stream().filter(p -> parameterValues.containsKey(p.getName())).collect(Collectors.toList());
+		return getComponent().getParameters().stream().filter(p -> parameterValues.containsKey(p.getName()))
+				.collect(Collectors.toList());
 	}
-	
+
 	public Collection<Parameter> getParametersThatHaveNotBeenSetExplicitly() {
 		return SetUtil.difference(component.getParameters(), getParametersThatHaveBeenSetExplicitly());
 	}
-	
+
 	public String getParameterValue(Parameter param) {
 		return getParameterValue(param.getName());
 	}
-	
+
 	public String getParameterValue(String param) {
 		return parameterValues.get(param);
 	}
 
 	/**
-	 * @return This method returns a mapping of interface IDs to component instances.
+	 * @return This method returns a mapping of interface IDs to component
+	 *         instances.
 	 */
 	public Map<String, ComponentInstance> getSatisfactionOfRequiredInterfaces() {
 		return this.satisfactionOfRequiredInterfaces;
@@ -69,6 +82,7 @@ public class ComponentInstance {
 		return sb.toString();
 	}
 
+	@JsonIgnore
 	public String getPrettyPrint() {
 		return getPrettyPrint(0);
 	}
@@ -105,7 +119,8 @@ public class ComponentInstance {
 		int result = 1;
 		result = prime * result + ((component == null) ? 0 : component.hashCode());
 		result = prime * result + ((parameterValues == null) ? 0 : parameterValues.hashCode());
-		result = prime * result + ((satisfactionOfRequiredInterfaces == null) ? 0 : satisfactionOfRequiredInterfaces.hashCode());
+		result = prime * result
+				+ ((satisfactionOfRequiredInterfaces == null) ? 0 : satisfactionOfRequiredInterfaces.hashCode());
 		return result;
 	}
 

--- a/softwareconfiguration/hasco/src/hasco/model/Parameter.java
+++ b/softwareconfiguration/hasco/src/hasco/model/Parameter.java
@@ -1,11 +1,16 @@
 package hasco.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"name", "defaultDomain", "defaultValue"})
 public class Parameter {
 	private final String name;
 	private final ParameterDomain defaultDomain;
 	private final Object defaultValue;
 
-	public Parameter(String name, ParameterDomain defaultDomain, Object defaultValue) {
+	
+	public Parameter(@JsonProperty("name") String name, @JsonProperty("defaultDomain")ParameterDomain defaultDomain,@JsonProperty("defaultValue") Object defaultValue) {
 		super();
 		this.name = name;
 		this.defaultDomain = defaultDomain;

--- a/softwareconfiguration/hasco/src/hasco/serialization/ComponentInstanceDeserializer.java
+++ b/softwareconfiguration/hasco/src/hasco/serialization/ComponentInstanceDeserializer.java
@@ -1,0 +1,70 @@
+package hasco.serialization;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.json.simple.JSONObject;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import hasco.model.Component;
+import hasco.model.ComponentInstance;
+
+public class ComponentInstanceDeserializer extends StdDeserializer<ComponentInstance> {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 4216559441244072999L;
+
+	public ComponentInstanceDeserializer() {
+		super(ComponentInstance.class);
+	}
+
+	public ComponentInstance readAsTree(TreeNode p) throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		// read the parameter values
+		Map<String, String> parameterValues = mapper.treeToValue(p.get("parameterValues"), HashMap.class);
+		// read the component
+
+		List<Object> componentList = new ArrayList();
+		componentList.add(p.get("component"));
+
+		ComponentLoader loader = new ComponentLoader();
+		JSONObject node = new JSONObject();
+		node.put("repository", "repository");
+		node.put("components", componentList);
+		
+		loader.readFromString(node.toJSONString());
+
+		Collection<Component> components = loader.getComponents();
+		Component component = null;
+		if (!components.isEmpty())
+			component = components.iterator().next();
+		
+		Map<String, ComponentInstance> satisfactionOfRequiredInterfaces = new HashMap<>();
+		// recursively resolve the requiredInterfaces
+		TreeNode n = p.get("satisfactionOfRequiredInterfaces");
+		Iterator<String> fields = n.fieldNames();
+		while (fields.hasNext()) {
+			String key = fields.next();
+			satisfactionOfRequiredInterfaces.put(key, readAsTree(n.get(key)));
+		}
+		return new ComponentInstance(component, parameterValues, satisfactionOfRequiredInterfaces);
+	}
+
+	@Override
+	public ComponentInstance deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+		return readAsTree(p.readValueAsTree());
+	}
+
+}

--- a/softwareconfiguration/hasco/src/hasco/serialization/ComponentLoader.java
+++ b/softwareconfiguration/hasco/src/hasco/serialization/ComponentLoader.java
@@ -113,6 +113,15 @@ public class ComponentLoader {
 				}
 			}
 		}
+		readFromJson(rootNode);
+	}
+	
+	public void readFromString(String json) throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		readFromJson(mapper.readTree(json));
+	}
+
+	private void readFromJson(JsonNode rootNode) throws IOException {
 		// get the array of components
 		JsonNode components = rootNode.path("components");
 		if (components != null) {

--- a/softwareconfiguration/hasco/src/hasco/serialization/HASCOJacksonModule.java
+++ b/softwareconfiguration/hasco/src/hasco/serialization/HASCOJacksonModule.java
@@ -1,0 +1,19 @@
+package hasco.serialization;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import hasco.model.ComponentInstance;
+
+public class HASCOJacksonModule extends SimpleModule {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public HASCOJacksonModule() {
+		super();
+		this.addDeserializer(ComponentInstance.class, new ComponentInstanceDeserializer());
+	}
+
+}

--- a/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/MLPlanARFFExample.java
+++ b/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/MLPlanARFFExample.java
@@ -21,7 +21,7 @@ public class MLPlanARFFExample {
 		/* load data for segment dataset and create a train-test-split */
 		Instances data = new Instances(new FileReader("../../../../../datasets/classification/multi-class/car.arff"));
 		data.setClassIndex(data.numAttributes() - 1);
-		List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(0), .7f);
+		List<Instances> split = WekaUtil.getStratifiedSplit(data, 0, .7f);
 
 		/* initialize mlplan with a tiny search space, and let it run for 30 seconds */
 		MLPlanWekaClassifier mlplan = new WekaMLPlanWekaClassifier(new MLPlanWekaBuilder().withSearchSpaceConfigFile(new File("conf/automl/searchmodels/weka/tinytest.json")));

--- a/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/MLPlanOpenMLExample.java
+++ b/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/MLPlanOpenMLExample.java
@@ -1,23 +1,25 @@
 package de.upb.crc901.mlplan.examples;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 
-import org.openml.apiconnector.io.OpenmlConnector;
-import org.openml.apiconnector.xml.DataSetDescription;
-
+import de.upb.crc901.mlpipeline_evaluation.PerformanceDBAdapter;
+import de.upb.crc901.mlplan.multiclass.wekamlplan.MLPlanWekaBuilder;
 import de.upb.crc901.mlplan.multiclass.wekamlplan.MLPlanWekaClassifier;
 import de.upb.crc901.mlplan.multiclass.wekamlplan.weka.WekaMLPlanWekaClassifier;
+import jaicore.basic.SQLAdapter;
 import jaicore.ml.WekaUtil;
+import jaicore.ml.cache.ReproducibleInstances;
+import jaicore.ml.core.evaluation.measure.singlelabel.MultiClassPerformanceMeasure;
 import weka.classifiers.Evaluation;
 import weka.core.Instances;
 
 /**
- * This is an example class that illustrates the usage of ML-Plan on the segment dataset of OpenML. It is configured to run for 30 seconds and to use 70% of the data for search and 30% for selection in its second phase.
+ * This is an example class that illustrates the usage of ML-Plan on the segment
+ * dataset of OpenML. It is configured to run for 30 seconds and to use 70% of
+ * the data for search and 30% for selection in its second phase.
  *
  * The API key used for OpenML is ML-Plan's key (read only).
  *
@@ -28,23 +30,30 @@ public class MLPlanOpenMLExample {
 
 	public static void main(final String[] args) throws Exception {
 
-		/* load data for segment dataset and create a train-test-split */
-		OpenmlConnector connector = new OpenmlConnector();
-		DataSetDescription ds = connector.dataGet(40983);
-		File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
-		Instances data = new Instances(new BufferedReader(new FileReader(file)));
+		
+		ReproducibleInstances data = ReproducibleInstances.fromOpenML("40983", "4350e421cdc16404033ef1812ea38c01");
 		data.setClassIndex(data.numAttributes() - 1);
-		List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(0), .7f);
+		List<Instances> split = WekaUtil.getStratifiedSplit((Instances)data, (new Random(0)).nextLong(), 0.7d);
 
+		
 		/* initialize mlplan, and let it run for 30 seconds */
-		MLPlanWekaClassifier mlplan = new WekaMLPlanWekaClassifier();
+
+		SQLAdapter adapter = new SQLAdapter("host", "user", "password", "database");
+        PerformanceDBAdapter pAdapter = new PerformanceDBAdapter(adapter, "performance_cache");
+
+		MLPlanWekaBuilder builder = new MLPlanWekaBuilder(
+				new File("conf/automl/searchmodels/weka/weka-all-autoweka.json"), new File("conf/mlplan.properties"),
+				MultiClassPerformanceMeasure.ERRORRATE, pAdapter);
+
+		MLPlanWekaClassifier mlplan = new WekaMLPlanWekaClassifier(builder);
+
 		mlplan.setLoggerName("mlplan");
-		mlplan.setTimeout(30);
-		mlplan.activateVisualization();
+		mlplan.setTimeout(60);
+		//mlplan.activateVisualization();
 		try {
 			long start = System.currentTimeMillis();
 			mlplan.buildClassifier(split.get(0));
-			long trainTime = (int)(System.currentTimeMillis() - start) / 1000;
+			long trainTime = (int) (System.currentTimeMillis() - start) / 1000;
 			System.out.println("Finished build of the classifier. Training time was " + trainTime + "s.");
 
 			/* evaluate solution produced by mlplan */

--- a/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/multiclass/weka/MLPlanWekaCLI.java
+++ b/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/multiclass/weka/MLPlanWekaCLI.java
@@ -68,7 +68,7 @@ public class MLPlanWekaCLI {
 			mlPlan.activateVisualization();
 
 		System.out.println(getTime() + " Split the data into train and test set...");
-		List<Instances> testSplit = WekaUtil.getStratifiedSplit(data, new Random(mlPlan.getConfig().randomSeed()), 0.7);
+		List<Instances> testSplit = WekaUtil.getStratifiedSplit(data, mlPlan.getConfig().randomSeed(), 0.7);
 		System.out.println("Data split created.");
 
 		try {

--- a/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/multiclass/weka/MLPlanWekaExperimenter.java
+++ b/softwareconfiguration/mlplan/examples/de/upb/crc901/mlplan/examples/multiclass/weka/MLPlanWekaExperimenter.java
@@ -83,7 +83,7 @@ public class MLPlanWekaExperimenter implements IExperimentSetEvaluator {
 		Instances data = new Instances(new FileReader(datasetFile));
 		data.setClassIndex(data.numAttributes() - 1);
 		print("Split instances");
-		List<Instances> stratifiedSplit = WekaUtil.getStratifiedSplit(data, new Random(), .7);
+		List<Instances> stratifiedSplit = WekaUtil.getStratifiedSplit(data, 0, .7);
 
 		/* initialize ML-Plan with the same config file that has been used to specify the experiments */
 		MLPlanWekaClassifier mlplan = new WekaMLPlanWekaClassifier(new MLPlanWekaBuilder().withAlgorithmConfigFile(configFile));

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/CacheEvaluatorMeasureBridge.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/CacheEvaluatorMeasureBridge.java
@@ -17,18 +17,24 @@ import jaicore.ml.evaluation.evaluators.weka.SimpleEvaluatorMeasureBridge;
 import weka.classifiers.Classifier;
 import weka.core.Instances;
 
+/**
+ * Implements a cache for the {@link AbstractEvaluatorMeasureBridge}. If no cache entry is found {@link SimpleEvaluatorMeasureBridge} is used.
+ * 
+ * @author mirko
+ *
+ */
 public class CacheEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge<Double, Double> {
 	
 	/** Logger for controlled output. */
-	static final Logger logger = LoggerFactory.getLogger(CacheEvaluatorMeasureBridge.class);
+	private static final Logger logger = LoggerFactory.getLogger(CacheEvaluatorMeasureBridge.class);
 
-	ComponentInstance evaluatedComponent;
+	private ComponentInstance evaluatedComponent;
 
 	/* Used for evaluating, when no cache entry could be found. */
-	SimpleEvaluatorMeasureBridge simpleEvaluatorMeasureBridge;
+	private SimpleEvaluatorMeasureBridge simpleEvaluatorMeasureBridge;
 
 	/* Used for looking up cache entries. */
-	PerformanceDBAdapter performanceDBAdapter;
+	private PerformanceDBAdapter performanceDBAdapter;
 
 	public CacheEvaluatorMeasureBridge(IMeasure<Double, Double> basicEvaluator,
 			PerformanceDBAdapter performanceDBAdapter) {
@@ -68,10 +74,10 @@ public class CacheEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge<
 
 	/**
 	 * Returns a lightweight copy of this object. That is, that the database
-	 * connection stays established and only the component instace is updated.
+	 * connection stays established and only the component instance is updated.
 	 * 
 	 * @param componentInstance
-	 * @return
+	 * @return the lightweight copy
 	 */
 	public CacheEvaluatorMeasureBridge getShallowCopy(ComponentInstance componentInstance) {
 		CacheEvaluatorMeasureBridge bridge = new CacheEvaluatorMeasureBridge(this.basicEvaluator,

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/CacheEvaluatorMeasureBridge.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/CacheEvaluatorMeasureBridge.java
@@ -1,0 +1,83 @@
+package de.upb.crc901.mlpipeline_evaluation;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.upb.crc901.mlplan.multiclass.wekamlplan.MLPlanWekaClassifier;
+import hasco.model.ComponentInstance;
+import jaicore.ml.cache.ReproducibleInstances;
+import jaicore.ml.core.evaluation.measure.IMeasure;
+import jaicore.ml.evaluation.evaluators.weka.AbstractEvaluatorMeasureBridge;
+import jaicore.ml.evaluation.evaluators.weka.MonteCarloCrossValidationEvaluator;
+import jaicore.ml.evaluation.evaluators.weka.SimpleEvaluatorMeasureBridge;
+import weka.classifiers.Classifier;
+import weka.core.Instances;
+
+public class CacheEvaluatorMeasureBridge extends AbstractEvaluatorMeasureBridge<Double, Double> {
+	
+	/** Logger for controlled output. */
+	static final Logger logger = LoggerFactory.getLogger(CacheEvaluatorMeasureBridge.class);
+
+	ComponentInstance evaluatedComponent;
+
+	/* Used for evaluating, when no cache entry could be found. */
+	SimpleEvaluatorMeasureBridge simpleEvaluatorMeasureBridge;
+
+	/* Used for looking up cache entries. */
+	PerformanceDBAdapter performanceDBAdapter;
+
+	public CacheEvaluatorMeasureBridge(IMeasure<Double, Double> basicEvaluator,
+			PerformanceDBAdapter performanceDBAdapter) {
+		super(basicEvaluator);
+		this.performanceDBAdapter = performanceDBAdapter;
+		this.simpleEvaluatorMeasureBridge = new SimpleEvaluatorMeasureBridge(basicEvaluator);
+	}
+
+	@Override
+	public Double evaluateSplit(Classifier pl, Instances trainingData, Instances validationData) throws Exception {
+		if (trainingData instanceof ReproducibleInstances) {
+
+			if (((ReproducibleInstances) trainingData).isCacheLookup()) {
+				// check in the cache if the result exists already
+				Optional<Double> potentialCache = performanceDBAdapter.exists(evaluatedComponent,
+						(ReproducibleInstances) trainingData, (ReproducibleInstances) validationData, simpleEvaluatorMeasureBridge.getBasicEvaluator().getClass().getName());
+				if (potentialCache.isPresent()) {
+					logger.debug("Cache hit");
+					return potentialCache.get();
+				}
+			}
+			logger.debug("Cache miss");
+			// query the underlying loss function
+			Instant start = Instant.now();
+			double performance = simpleEvaluatorMeasureBridge.evaluateSplit(pl, trainingData, validationData);
+			Instant end = Instant.now();
+			Duration delta = Duration.between(start, end);
+			// cache it
+			if (((ReproducibleInstances) trainingData).isCacheStorage()) {
+				performanceDBAdapter.store(evaluatedComponent, (ReproducibleInstances) trainingData, (ReproducibleInstances) validationData, performance, simpleEvaluatorMeasureBridge.getBasicEvaluator().getClass().getName(), delta.toMillis());
+			}
+			return performance;
+		} else {
+			return simpleEvaluatorMeasureBridge.evaluateSplit(pl, trainingData, validationData);
+		}
+	}
+
+	/**
+	 * Returns a lightweight copy of this object. That is, that the database
+	 * connection stays established and only the component instace is updated.
+	 * 
+	 * @param componentInstance
+	 * @return
+	 */
+	public CacheEvaluatorMeasureBridge getShallowCopy(ComponentInstance componentInstance) {
+		CacheEvaluatorMeasureBridge bridge = new CacheEvaluatorMeasureBridge(this.basicEvaluator,
+				this.performanceDBAdapter);
+		bridge.evaluatedComponent = componentInstance;
+		return bridge;
+	}
+
+}

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/ConsistentMLPipelineEvaluator.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/ConsistentMLPipelineEvaluator.java
@@ -10,6 +10,7 @@ import jaicore.ml.WekaUtil;
 import jaicore.ml.core.evaluation.measure.singlelabel.ZeroOneLoss;
 import jaicore.ml.evaluation.evaluators.weka.IClassifierEvaluator;
 import jaicore.ml.evaluation.evaluators.weka.MonteCarloCrossValidationEvaluator;
+import jaicore.ml.evaluation.evaluators.weka.SimpleEvaluatorMeasureBridge;
 import weka.classifiers.Classifier;
 import weka.classifiers.Evaluation;
 import weka.core.Instances;
@@ -96,7 +97,7 @@ public class ConsistentMLPipelineEvaluator {
 
 		switch (techniqueAndDescription[0]) {
 		case "3MCCV":
-			return new MonteCarloCrossValidationEvaluator(new ZeroOneLoss(), 3, data,
+			return new MonteCarloCrossValidationEvaluator(new SimpleEvaluatorMeasureBridge(new ZeroOneLoss()), 3, data,
 					Float.parseFloat(techniqueAndDescription[1]), seed);
 		}
 

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/PerformanceDBAdapter.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/PerformanceDBAdapter.java
@@ -27,15 +27,18 @@ import jaicore.basic.SQLAdapter;
 import jaicore.ml.cache.ReproducibleInstances;
 
 /**
- * Database adapter for performance data
+ * Database adapter for performance data. Functionality to store and save
+ * performance values in a database. json to reproduce the
+ * {@link ReproducibleInstances} is saved as well as the solution that produced
+ * the performance value.
  * 
  * @author jmhansel
  *
  */
-public class PerformanceDBAdapter implements Closeable {	/** Logger for controlled output. */
-	static final Logger logger = LoggerFactory.getLogger(CacheEvaluatorMeasureBridge.class);
+public class PerformanceDBAdapter implements Closeable {
+	/** Logger for controlled output. */
+	private static final Logger logger = LoggerFactory.getLogger(PerformanceDBAdapter.class);
 
-	
 	private final SQLAdapter sqlAdapter;
 	private final String performanceSampleTableName;
 
@@ -79,17 +82,14 @@ public class PerformanceDBAdapter implements Closeable {	/** Logger for controll
 	 * corresponding performance score.
 	 * 
 	 * 
-	 * @param composition
-	 *            - Solution composition.
-	 * @param reproducableInstances
-	 *            - Instances object that includes the trajectory, i.e. all
-	 *            operations that have been applied to the instances like loading,
-	 *            splitting etc.
-	 * @param testData
-	 *            - The reproducible instances of the test data used for this
-	 *            evaluation process
-	 * @param className
-	 *            - the java qualified class name of the loss function that was used
+	 * @param composition           - Solution composition.
+	 * @param reproducableInstances - Instances object that includes the trajectory,
+	 *                              i.e. all operations that have been applied to
+	 *                              the instances like loading, splitting etc.
+	 * @param testData              - The reproducible instances of the test data
+	 *                              used for this evaluation process
+	 * @param className             - the java qualified class name of the loss
+	 *                              function that was used
 	 * @return opt - Optional that contains the score corresponding to the
 	 *         composition and the reproducible instances or is empty if no suiting
 	 *         entry is found in the database.
@@ -120,27 +120,23 @@ public class PerformanceDBAdapter implements Closeable {	/** Logger for controll
 		}
 		return opt;
 	}
-	
 
 	/**
 	 * Stores the composition, the trajectory and the achieved score in the
 	 * database.
 	 * 
-	 * @param composition
-	 *            - Solution composition
-	 * @param reproducableInstances
-	 *            - Instances object that includes the trajectory, i.e. all
-	 *            operations that have been applied to the instances like loading,
-	 *            splitting etc.
-	 * @param testData
-	 *            - The reproducible instances of the test data used for this
-	 *            evaluation process
-	 * @param score
-	 *            - Score achieved by the composition on the reproducible instances
-	 * @param className
-	 *            - The java qualified class name of the loss function that was used
-	 * @param evaluationTime
-	 *            - The time it took for the corresponding evaluation in milliseconds
+	 * @param composition           - Solution composition
+	 * @param reproducableInstances - Instances object that includes the trajectory,
+	 *                              i.e. all operations that have been applied to
+	 *                              the instances like loading, splitting etc.
+	 * @param testData              - The reproducible instances of the test data
+	 *                              used for this evaluation process
+	 * @param score                 - Score achieved by the composition on the
+	 *                              reproducible instances
+	 * @param className             - The java qualified class name of the loss
+	 *                              function that was used
+	 * @param evaluationTime        - The time it took for the corresponding
+	 *                              evaluation in milliseconds
 	 */
 	public void store(ComponentInstance composition, ReproducibleInstances reproducibleInstances,
 			ReproducibleInstances testData, double score, String className, long evaluationTime) {

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/PerformanceDBAdapter.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlpipeline_evaluation/PerformanceDBAdapter.java
@@ -1,0 +1,184 @@
+package de.upb.crc901.mlpipeline_evaluation;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hasco.model.ComponentInstance;
+import jaicore.basic.SQLAdapter;
+import jaicore.ml.cache.ReproducibleInstances;
+
+/**
+ * Database adapter for performance data
+ * 
+ * @author jmhansel
+ *
+ */
+public class PerformanceDBAdapter implements Closeable {	/** Logger for controlled output. */
+	static final Logger logger = LoggerFactory.getLogger(CacheEvaluatorMeasureBridge.class);
+
+	
+	private final SQLAdapter sqlAdapter;
+	private final String performanceSampleTableName;
+
+	public PerformanceDBAdapter(SQLAdapter sqlAdapter, String performanceSampleTableName) {
+		this.sqlAdapter = sqlAdapter;
+		this.performanceSampleTableName = performanceSampleTableName;
+
+		/* initialize tables if not existent */
+		try {
+			ResultSet rs = sqlAdapter.getResultsOfQuery("SHOW TABLES");
+			boolean hasPerformanceTable = false;
+			while (rs.next()) {
+				String tableName = rs.getString(1);
+				if (tableName.equals(this.performanceSampleTableName))
+					hasPerformanceTable = true;
+			}
+
+			// if there is no performance table, create it. we hash the composition and
+			// trajectory and use the hash value as primary key for performance reasons.
+			if (!hasPerformanceTable) {
+				logger.info("Creating table for evaluations");
+				sqlAdapter.update("CREATE TABLE `" + this.performanceSampleTableName + "` (\r\n"
+						+ " `evaluation_id` int(10) NOT NULL AUTO_INCREMENT,\r\n" + " `composition` json NOT NULL,\r\n"
+						+ " `train_trajectory` json NOT NULL,\r\n" + " `test_trajectory` json NOT NULL,\r\n"
+						+ " `loss_function` varchar(200) NOT NULL,\r\n" + " `score` double NOT NULL,\r\n"
+						+ " `evaluation_time_ms` bigint NOT NULL,\r\n"
+						+ "`evaluation_date` timestamp NULL DEFAULT NULL," + "`hash_value` char(64) NOT NULL,"
+						+ " PRIMARY KEY (`evaluation_id`)\r\n"
+						+ ") ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE=utf8_bin", new ArrayList<>());
+			}
+
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	/**
+	 * Checks whether there is an entry for the composition and corresponding
+	 * evaluation specified by the reproducable instances. If so, it returns the
+	 * corresponding performance score.
+	 * 
+	 * 
+	 * @param composition
+	 *            - Solution composition.
+	 * @param reproducableInstances
+	 *            - Instances object that includes the trajectory, i.e. all
+	 *            operations that have been applied to the instances like loading,
+	 *            splitting etc.
+	 * @param testData
+	 *            - The reproducible instances of the test data used for this
+	 *            evaluation process
+	 * @param className
+	 *            - the java qualified class name of the loss function that was used
+	 * @return opt - Optional that contains the score corresponding to the
+	 *         composition and the reproducible instances or is empty if no suiting
+	 *         entry is found in the database.
+	 */
+	public Optional<Double> exists(ComponentInstance composition, ReproducibleInstances reproducibleInstances,
+			ReproducibleInstances testData, String className) {
+		Optional<Double> opt = Optional.empty();
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			String compositionString = mapper.writeValueAsString(composition);
+			String trainTrajectoryString = mapper.writeValueAsString(reproducibleInstances.getInstructions());
+			String testTrajectoryString = mapper.writeValueAsString(testData.getInstructions());
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			md.update(compositionString.getBytes());
+			md.update(trainTrajectoryString.getBytes());
+			md.update(testTrajectoryString.getBytes());
+			md.update(className.getBytes());
+			byte[] digest = md.digest();
+			String hexHash = (new HexBinaryAdapter()).marshal(digest);
+			ResultSet rs = sqlAdapter.getResultsOfQuery(
+					"SELECT score FROM " + this.performanceSampleTableName + " WHERE hash_value = '" + hexHash + "'");
+			while (rs.next()) {
+				double score = rs.getDouble("score");
+				opt = Optional.of(score);
+			}
+		} catch (JsonProcessingException | SQLException | NoSuchAlgorithmException e) {
+			e.printStackTrace();
+		}
+		return opt;
+	}
+	
+
+	/**
+	 * Stores the composition, the trajectory and the achieved score in the
+	 * database.
+	 * 
+	 * @param composition
+	 *            - Solution composition
+	 * @param reproducableInstances
+	 *            - Instances object that includes the trajectory, i.e. all
+	 *            operations that have been applied to the instances like loading,
+	 *            splitting etc.
+	 * @param testData
+	 *            - The reproducible instances of the test data used for this
+	 *            evaluation process
+	 * @param score
+	 *            - Score achieved by the composition on the reproducible instances
+	 * @param className
+	 *            - The java qualified class name of the loss function that was used
+	 * @param evaluationTime
+	 *            - The time it took for the corresponding evaluation in milliseconds
+	 */
+	public void store(ComponentInstance composition, ReproducibleInstances reproducibleInstances,
+			ReproducibleInstances testData, double score, String className, long evaluationTime) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			String compositionString = mapper.writeValueAsString(composition);
+			String trainTrajectoryString = mapper.writeValueAsString(reproducibleInstances.getInstructions());
+			String testTrajectoryString = mapper.writeValueAsString(testData.getInstructions());
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			md.update(compositionString.getBytes());
+			md.update(trainTrajectoryString.getBytes());
+			md.update(testTrajectoryString.getBytes());
+			md.update(className.getBytes());
+			byte[] digest = md.digest();
+			String hexHash = (new HexBinaryAdapter()).marshal(digest);
+			ResultSet rs = sqlAdapter.getResultsOfQuery(
+					"SELECT score FROM " + this.performanceSampleTableName + " WHERE hash_value = '" + hexHash + "'");
+			if (rs.next())
+				return;
+			Map<String, String> valueMap = new HashMap<>();
+			valueMap.put("composition", compositionString);
+			valueMap.put("train_trajectory", trainTrajectoryString);
+			valueMap.put("test_trajectory", testTrajectoryString);
+			valueMap.put("loss_function", className);
+			valueMap.put("evaluation_date",
+					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(Date.from(Instant.now())));
+			valueMap.put("evaluation_time_ms", Long.toString(evaluationTime));
+			valueMap.put("hash_value", hexHash);
+			valueMap.put("score", Double.toString(score));
+			this.sqlAdapter.insert(this.performanceSampleTableName, valueMap);
+		} catch (JsonProcessingException | NoSuchAlgorithmException | SQLException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.sqlAdapter.close();
+	}
+
+}

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/MLPlanClassifierConfig.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/MLPlanClassifierConfig.java
@@ -24,7 +24,7 @@ public interface MLPlanClassifierConfig extends TwoPhaseHASCOConfig {
 
 	@Key(SEARCH_MCCV_FOLDSIZE)
 	@DefaultValue(".7")
-	public float getMCCVTrainFoldSizeDuringSearch();
+	public double getMCCVTrainFoldSizeDuringSearch();
 
 	@Key(SELECTION_MCCV_ITERATIONS)
 	@DefaultValue("5")
@@ -32,11 +32,11 @@ public interface MLPlanClassifierConfig extends TwoPhaseHASCOConfig {
 
 	@Key(SELECTION_MCCV_FOLDSIZE)
 	@DefaultValue(".7")
-	public float getMCCVTrainFoldSizeDuringSelection();
+	public double getMCCVTrainFoldSizeDuringSelection();
 
 	@Key(SELECTION_PORTION)
 	@DefaultValue("0.3")
-	public float dataPortionForSelection();
+	public double dataPortionForSelection();
 
 //	@Key(TIMEOUT_PER_EVAL_IN_SECONDS)
 //	@DefaultValue("10")

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/MLPlanWekaBuilder.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/MLPlanWekaBuilder.java
@@ -2,13 +2,16 @@ package de.upb.crc901.mlplan.multiclass.wekamlplan;
 
 import java.io.File;
 
+import de.upb.crc901.mlpipeline_evaluation.PerformanceDBAdapter;
 import jaicore.ml.core.evaluation.measure.singlelabel.MultiClassPerformanceMeasure;
 
 public class MLPlanWekaBuilder {
 	private File searchSpaceConfigFile = new File("conf/automl/searchmodels/weka/weka-all-autoweka.json");
 	private File alhorithmConfigFile = new File("conf/mlplan.properties");
 	private MultiClassPerformanceMeasure performanceMeasure = MultiClassPerformanceMeasure.ERRORRATE;
-
+	private boolean useCache = false;
+	private PerformanceDBAdapter dbAdapter = null;
+	
 	public MLPlanWekaBuilder() { }
 	
 	public MLPlanWekaBuilder(File searchSpaceConfigFile, File alhorithmConfigFile, MultiClassPerformanceMeasure performanceMeasure) {
@@ -16,7 +19,18 @@ public class MLPlanWekaBuilder {
 		this.searchSpaceConfigFile = searchSpaceConfigFile;
 		this.alhorithmConfigFile = alhorithmConfigFile;
 		this.performanceMeasure = performanceMeasure;
+		this.useCache = false;
 	}
+	
+	public MLPlanWekaBuilder(File searchSpaceConfigFile, File alhorithmConfigFile, MultiClassPerformanceMeasure performanceMeasure, PerformanceDBAdapter dbAdapter) {
+		super();
+		this.searchSpaceConfigFile = searchSpaceConfigFile;
+		this.alhorithmConfigFile = alhorithmConfigFile;
+		this.performanceMeasure = performanceMeasure;
+		this.useCache = true;
+		this.dbAdapter = dbAdapter;
+	}
+	
 
 	public File getSearchSpaceConfigFile() {
 		return searchSpaceConfigFile;
@@ -44,4 +58,13 @@ public class MLPlanWekaBuilder {
 		this.performanceMeasure = performanceMeasure;
 		return this;
 	}
+	
+	public boolean getUseCache() {
+		return useCache;
+	}
+	
+	public PerformanceDBAdapter getDBAdapter() {
+		return dbAdapter;
+	}
+	
 }

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/MLPlanWekaClassifier.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/MLPlanWekaClassifier.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
+import de.upb.crc901.mlpipeline_evaluation.CacheEvaluatorMeasureBridge;
 import de.upb.crc901.mlplan.multiclass.MLPlanClassifierConfig;
 import hasco.core.HASCOSolutionCandidate;
 import hasco.model.Component;
@@ -37,8 +38,8 @@ import jaicore.basic.algorithm.AlgorithmState;
 import jaicore.basic.algorithm.IAlgorithm;
 import jaicore.basic.algorithm.SolutionCandidateFoundEvent;
 import jaicore.ml.WekaUtil;
-import jaicore.ml.core.evaluation.measure.ADecomposableDoubleMeasure;
 import jaicore.ml.core.evaluation.measure.singlelabel.MultiClassPerformanceMeasure;
+import jaicore.ml.evaluation.evaluators.weka.AbstractEvaluatorMeasureBridge;
 import jaicore.ml.evaluation.evaluators.weka.MonteCarloCrossValidationEvaluator;
 import jaicore.planning.graphgenerators.task.tfd.TFDNode;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.AlternativeNodeEvaluator;
@@ -54,14 +55,17 @@ import weka.core.Option;
 import weka.core.OptionHandler;
 
 /**
- * A WEKA classifier wrapping the functionality of ML-Plan where the constructed object is a WEKA classifier.
+ * A WEKA classifier wrapping the functionality of ML-Plan where the constructed
+ * object is a WEKA classifier.
  *
- * It implements the algorithm interface with itself (with modified state) as an output
+ * It implements the algorithm interface with itself (with modified state) as an
+ * output
  *
  * @author wever, fmohr
  *
  */
-public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHandler, OptionHandler, ILoggingCustomizable, IAlgorithm<Instances, Classifier> {
+public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHandler, OptionHandler,
+		ILoggingCustomizable, IAlgorithm<Instances, Classifier> {
 
 	/** Logger for controlled output. */
 	private Logger logger = LoggerFactory.getLogger(MLPlanWekaClassifier.class);
@@ -71,7 +75,7 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 	private final Collection<Component> components;
 	private final ClassifierFactory factory;
 	private INodeEvaluator<TFDNode, Double> preferredNodeEvaluator;
-	private final ADecomposableDoubleMeasure<Double> performanceMeasure;
+	private final AbstractEvaluatorMeasureBridge<Double, Double> evaluationMeasurementBridge;
 	private final MLPlanClassifierConfig config;
 	private Classifier selectedClassifier;
 	private double internalValidationErrorOfSelectedClassifier;
@@ -83,11 +87,13 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 	private Instances dataShownToSearch = null;
 	private Instances data = null;
 
-	public MLPlanWekaClassifier(final File componentFile, final ClassifierFactory factory, final ADecomposableDoubleMeasure<Double> performanceMeasure, final MLPlanClassifierConfig config) throws IOException {
+	public MLPlanWekaClassifier(final File componentFile, final ClassifierFactory factory,
+			final AbstractEvaluatorMeasureBridge<Double, Double> evaluationMeasurementBridge,
+			final MLPlanClassifierConfig config) throws IOException {
 		this.componentFile = componentFile;
 		this.components = new ComponentLoader(componentFile).getComponents();
 		this.factory = factory;
-		this.performanceMeasure = performanceMeasure;
+		this.evaluationMeasurementBridge = evaluationMeasurementBridge;
 		this.config = config;
 	}
 
@@ -121,9 +127,10 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 			}
 
 			/* set up exact splits */
-			float selectionDataPortion = this.config.dataPortionForSelection();
+			double selectionDataPortion = this.config.dataPortionForSelection();
 			if (selectionDataPortion > 0) {
-				List<Instances> selectionSplit = WekaUtil.getStratifiedSplit(this.data, new Random(this.config.randomSeed()), selectionDataPortion);
+				List<Instances> selectionSplit = WekaUtil.getStratifiedSplit(this.data,
+						this.config.randomSeed(), selectionDataPortion);
 				this.dataShownToSearch = selectionSplit.get(1);
 			} else {
 				this.dataShownToSearch = this.data;
@@ -133,47 +140,83 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 			}
 
 			/* dynamically compute blow-ups */
-			double blowUpInSelectionPhase = MathExt.round(1f / this.config.getMCCVTrainFoldSizeDuringSearch() * this.config.numberOfMCIterationsDuringSelection() / this.config.numberOfMCIterationsDuringSearch(), 2);
-			double blowUpInPostprocessing = MathExt.round((1 / (1 - this.config.dataPortionForSelection())) / this.config.numberOfMCIterationsDuringSelection(), 2);
+			double blowUpInSelectionPhase = MathExt.round(1f / this.config.getMCCVTrainFoldSizeDuringSearch()
+					* this.config.numberOfMCIterationsDuringSelection()
+					/ this.config.numberOfMCIterationsDuringSearch(), 2);
+			double blowUpInPostprocessing = MathExt.round((1 / (1 - this.config.dataPortionForSelection()))
+					/ this.config.numberOfMCIterationsDuringSelection(), 2);
 			this.config.setProperty(MLPlanClassifierConfig.K_BLOWUP_SELECTION, String.valueOf(blowUpInSelectionPhase));
-			this.config.setProperty(MLPlanClassifierConfig.K_BLOWUP_POSTPROCESS, String.valueOf(blowUpInPostprocessing));
+			this.config.setProperty(MLPlanClassifierConfig.K_BLOWUP_POSTPROCESS,
+					String.valueOf(blowUpInPostprocessing));
 
 			/* communicate the parameters with which ML-Plan will run */
 			this.logger.info(
 					"Starting ML-Plan with the following setup:\n\tDataset: {}\n\tTarget: {}\n\tCPUs: {}\n\tTimeout: {}s\n\tTimeout for single candidate evaluation: {}s\n\tTimeout for node evaluation: {}s\n\tRandom Completions per node evaluation: {}\n\tPortion of data for selection phase: {}%\n\tMCCV for search: {} iterations with {}% for training\n\tMCCV for select: {} iterations with {}% for training\n\tBlow-ups are {} for selection phase and {} for post-processing phase.",
-					this.data.relationName(), MultiClassPerformanceMeasure.ERRORRATE, this.config.cpus(), this.config.timeout(), this.config.timeoutForCandidateEvaluation() / 1000, this.config.timeoutForNodeEvaluation() / 1000,
-					this.config.randomCompletions(), MathExt.round(this.config.dataPortionForSelection() * 100, 2), this.config.numberOfMCIterationsDuringSearch(), (int) (100 * this.config.getMCCVTrainFoldSizeDuringSearch()),
-					this.config.numberOfMCIterationsDuringSelection(), (int) (100 * this.config.getMCCVTrainFoldSizeDuringSelection()), this.config.expectedBlowupInSelection(), this.config.expectedBlowupInPostprocessing());
+					this.data.relationName(), MultiClassPerformanceMeasure.ERRORRATE, this.config.cpus(),
+					this.config.timeout(), this.config.timeoutForCandidateEvaluation() / 1000,
+					this.config.timeoutForNodeEvaluation() / 1000, this.config.randomCompletions(),
+					MathExt.round(this.config.dataPortionForSelection() * 100, 2),
+					this.config.numberOfMCIterationsDuringSearch(),
+					(int) (100 * this.config.getMCCVTrainFoldSizeDuringSearch()),
+					this.config.numberOfMCIterationsDuringSelection(),
+					(int) (100 * this.config.getMCCVTrainFoldSizeDuringSelection()),
+					this.config.expectedBlowupInSelection(), this.config.expectedBlowupInPostprocessing());
 			this.logger.info("Using the following preferred node evaluator: {}", this.preferredNodeEvaluator);
 
 			/* create HASCO problem */
-			IObjectEvaluator<Classifier, Double> searchBenchmark = new MonteCarloCrossValidationEvaluator(this.performanceMeasure, this.config.numberOfMCIterationsDuringSearch(), this.dataShownToSearch,
-					this.config.getMCCVTrainFoldSizeDuringSearch(), this.config.randomSeed());
-			IObjectEvaluator<ComponentInstance, Double> wrappedSearchBenchmark = c -> searchBenchmark.evaluate(this.factory.getComponentInstantiation(c));
-			IObjectEvaluator<Classifier, Double> selectionBenchmark = new IObjectEvaluator<Classifier, Double>() {
+			IObjectEvaluator<Classifier, Double> searchBenchmark = new MonteCarloCrossValidationEvaluator(
+					this.evaluationMeasurementBridge, this.config.numberOfMCIterationsDuringSearch(),
+					this.dataShownToSearch, this.config.getMCCVTrainFoldSizeDuringSearch(), this.config.randomSeed());
+			
 
-				@Override
-				public Double evaluate(final Classifier object) throws Exception {
-
-					/* first conduct MCCV */
-					MonteCarloCrossValidationEvaluator mccv = new MonteCarloCrossValidationEvaluator(MLPlanWekaClassifier.this.performanceMeasure, MLPlanWekaClassifier.this.config.numberOfMCIterationsDuringSelection(),
-							MLPlanWekaClassifier.this.data, MLPlanWekaClassifier.this.config.getMCCVTrainFoldSizeDuringSelection(), config.randomSeed());
-					mccv.evaluate(object);
-
-					/* now retrieve .75-percentile from stats */
-					double mean = mccv.getStats().getMean();
-					double percentile = mccv.getStats().getPercentile(75f);
-					MLPlanWekaClassifier.this.logger.info("Select {} as .75-percentile where {} would have been the mean. Samples size of MCCV was {}", percentile, mean, mccv.getStats().getN());
-					return percentile;
+			IObjectEvaluator<ComponentInstance, Double> wrappedSearchBenchmark = c -> {
+				if (evaluationMeasurementBridge instanceof CacheEvaluatorMeasureBridge) {
+					CacheEvaluatorMeasureBridge bridge = ((CacheEvaluatorMeasureBridge) evaluationMeasurementBridge)
+							.getShallowCopy(c);
+				
+					
+					long seed = this.getConfig().randomSeed() + c.hashCode();
+					
+					IObjectEvaluator<Classifier, Double> copiedSearchBenchmark = new MonteCarloCrossValidationEvaluator(
+							bridge, this.config.numberOfMCIterationsDuringSearch(), this.dataShownToSearch,
+							this.config.getMCCVTrainFoldSizeDuringSearch(), seed);
+					return copiedSearchBenchmark.evaluate(this.factory.getComponentInstantiation(c));
 				}
+				return searchBenchmark.evaluate(this.factory.getComponentInstantiation(c));
 			};
-			IObjectEvaluator<ComponentInstance, Double> wrappedSelectionBenchmark = c -> selectionBenchmark.evaluate(this.factory.getComponentInstantiation(c));
-			TwoPhaseSoftwareConfigurationProblem problem = new TwoPhaseSoftwareConfigurationProblem(this.componentFile, "AbstractClassifier", wrappedSearchBenchmark, wrappedSelectionBenchmark);
+
+			IObjectEvaluator<ComponentInstance, Double> wrappedSelectionBenchmark = c -> {
+				/* first conduct MCCV */
+				AbstractEvaluatorMeasureBridge<Double, Double> bridge = evaluationMeasurementBridge;
+				if (evaluationMeasurementBridge instanceof CacheEvaluatorMeasureBridge) {
+					bridge = ((CacheEvaluatorMeasureBridge) bridge).getShallowCopy(c);
+
+				}
+
+				MonteCarloCrossValidationEvaluator mccv = new MonteCarloCrossValidationEvaluator(bridge,
+						MLPlanWekaClassifier.this.config.numberOfMCIterationsDuringSelection(),
+						MLPlanWekaClassifier.this.data,
+						MLPlanWekaClassifier.this.config.getMCCVTrainFoldSizeDuringSelection(), config.randomSeed());
+				mccv.evaluate(this.factory.getComponentInstantiation(c));
+
+				/* now retrieve .75-percentile from stats */
+				double mean = mccv.getStats().getMean();
+				double percentile = mccv.getStats().getPercentile(75f);
+				MLPlanWekaClassifier.this.logger.info(
+						"Select {} as .75-percentile where {} would have been the mean. Samples size of MCCV was {}",
+						percentile, mean, mccv.getStats().getN());
+				return percentile;
+			};
+
+			TwoPhaseSoftwareConfigurationProblem problem = new TwoPhaseSoftwareConfigurationProblem(this.componentFile,
+					"AbstractClassifier", wrappedSearchBenchmark, wrappedSelectionBenchmark);
 
 			/* configure and start optimizing factory */
-			OptimizingFactoryProblem<TwoPhaseSoftwareConfigurationProblem, Classifier, Double> optimizingFactoryProblem = new OptimizingFactoryProblem<>(this.factory, problem);
+			OptimizingFactoryProblem<TwoPhaseSoftwareConfigurationProblem, Classifier, Double> optimizingFactoryProblem = new OptimizingFactoryProblem<>(
+					this.factory, problem);
 			this.hascoFactory = new TwoPhaseHASCOFactory();
-			this.hascoFactory.setPreferredNodeEvaluator(new AlternativeNodeEvaluator<TFDNode, Double>(this.getSemanticNodeEvaluator(this.dataShownToSearch), this.preferredNodeEvaluator));
+			this.hascoFactory.setPreferredNodeEvaluator(new AlternativeNodeEvaluator<TFDNode, Double>(
+					this.getSemanticNodeEvaluator(this.dataShownToSearch), this.preferredNodeEvaluator));
 			this.hascoFactory.setConfig(this.config);
 			this.optimizingFactory = new OptimizingFactory<>(optimizingFactoryProblem, this.hascoFactory);
 			this.optimizingFactory.setLoggerName(this.loggerName + ".2phasehasco");
@@ -194,7 +237,9 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 			long startBuildTime = System.currentTimeMillis();
 			this.selectedClassifier.buildClassifier(this.data);
 			long endBuildTime = System.currentTimeMillis();
-			this.logger.info("Selected model has been built on entire dataset. Build time of chosen model was {}ms. Total construction time was {}ms", endBuildTime - startBuildTime, endBuildTime - startOptimizationTime);
+			this.logger.info(
+					"Selected model has been built on entire dataset. Build time of chosen model was {}ms. Total construction time was {}ms",
+					endBuildTime - startBuildTime, endBuildTime - startOptimizationTime);
 			this.state = AlgorithmState.inactive;
 			return new AlgorithmFinishedEvent();
 		}
@@ -350,7 +395,7 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 	public void activateVisualization() {
 		this.config.setProperty(MLPlanClassifierConfig.K_VISUALIZE, String.valueOf(true));
 	}
-	
+
 	public void deactivateVisualization() {
 		this.config.setProperty(MLPlanClassifierConfig.K_VISUALIZE, String.valueOf(false));
 	}
@@ -377,11 +422,13 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 	}
 
 	public void setTimeoutForSingleSolutionEvaluation(final int timeout) {
-		this.config.setProperty(MLPlanClassifierConfig.K_RANDOM_COMPLETIONS_TIMEOUT_PATH, String.valueOf(timeout * 1000));
+		this.config.setProperty(MLPlanClassifierConfig.K_RANDOM_COMPLETIONS_TIMEOUT_PATH,
+				String.valueOf(timeout * 1000));
 	}
 
 	public void setTimeoutForNodeEvaluation(final int timeout) {
-		this.config.setProperty(MLPlanClassifierConfig.K_RANDOM_COMPLETIONS_TIMEOUT_NODE, String.valueOf(timeout * 1000));
+		this.config.setProperty(MLPlanClassifierConfig.K_RANDOM_COMPLETIONS_TIMEOUT_NODE,
+				String.valueOf(timeout * 1000));
 	}
 
 	public Collection<Component> getComponents() {
@@ -398,7 +445,8 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 			throw new IllegalArgumentException("Need to work with at least one CPU");
 		}
 		if (num > Runtime.getRuntime().availableProcessors()) {
-			this.logger.warn("Warning, configuring {} CPUs where the system has only {}", num, Runtime.getRuntime().availableProcessors());
+			this.logger.warn("Warning, configuring {} CPUs where the system has only {}", num,
+					Runtime.getRuntime().availableProcessors());
 		}
 		this.config.setProperty(MLPlanClassifierConfig.K_CPUS, String.valueOf(num));
 	}
@@ -407,7 +455,9 @@ public abstract class MLPlanWekaClassifier implements Classifier, CapabilitiesHa
 	public void receiveSolutionEvent(final SolutionCandidateFoundEvent<HASCOSolutionCandidate<Double>> event) {
 		HASCOSolutionCandidate<Double> solution = event.getSolutionCandidate();
 		try {
-			this.logger.info("Received new solution {} with score {} and evaluation time {}ms", this.factory.getComponentInstantiation(solution.getComponentInstance()), solution.getScore(), solution.getTimeToEvaluateCandidate());
+			this.logger.info("Received new solution {} with score {} and evaluation time {}ms",
+					this.factory.getComponentInstantiation(solution.getComponentInstance()), solution.getScore(),
+					solution.getTimeToEvaluateCandidate());
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/weka/WekaMLPlanWekaClassifier.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/mlplan/multiclass/wekamlplan/weka/WekaMLPlanWekaClassifier.java
@@ -7,12 +7,16 @@ import java.util.Properties;
 
 import org.aeonbits.owner.ConfigFactory;
 
+import de.upb.crc901.mlpipeline_evaluation.CacheEvaluatorMeasureBridge;
 import de.upb.crc901.mlplan.multiclass.MLPlanClassifierConfig;
 import de.upb.crc901.mlplan.multiclass.wekamlplan.MLPlanWekaBuilder;
 import de.upb.crc901.mlplan.multiclass.wekamlplan.MLPlanWekaClassifier;
 import hasco.serialization.ComponentLoader;
 import jaicore.basic.FileUtil;
+import jaicore.ml.core.evaluation.measure.ADecomposableDoubleMeasure;
 import jaicore.ml.core.evaluation.measure.singlelabel.MultiClassMeasureBuilder;
+import jaicore.ml.evaluation.evaluators.weka.AbstractEvaluatorMeasureBridge;
+import jaicore.ml.evaluation.evaluators.weka.SimpleEvaluatorMeasureBridge;
 import jaicore.planning.graphgenerators.task.tfd.TFDNode;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.INodeEvaluator;
 import weka.core.Instances;
@@ -31,9 +35,20 @@ public class WekaMLPlanWekaClassifier extends MLPlanWekaClassifier {
 	}
 
 	public WekaMLPlanWekaClassifier(MLPlanWekaBuilder builder) throws IOException {
-		super(builder.getSearchSpaceConfigFile(), new WEKAPipelineFactory(), new MultiClassMeasureBuilder().getEvaluator(builder.getPerformanceMeasure()), builder.getAlhorithmConfigFile() != null ? loadOwnerConfig(builder.getAlhorithmConfigFile()) : ConfigFactory.create(MLPlanClassifierConfig.class));
+		super(builder.getSearchSpaceConfigFile(), new WEKAPipelineFactory(), getBridge(builder), builder.getAlhorithmConfigFile() != null ? loadOwnerConfig(builder.getAlhorithmConfigFile()) : ConfigFactory.create(MLPlanClassifierConfig.class));
 		PreferenceBasedNodeEvaluator preferenceNodeEvaluator = new PreferenceBasedNodeEvaluator(new ComponentLoader(getComponentFile()).getComponents(), FileUtil.readFileAsList(getConfig().preferredComponents()));
 		this.setPreferredNodeEvaluator(preferenceNodeEvaluator);
+	}
+	
+	private static AbstractEvaluatorMeasureBridge<Double, Double> getBridge(MLPlanWekaBuilder builder){
+		ADecomposableDoubleMeasure<Double> measure = new MultiClassMeasureBuilder().getEvaluator(builder.getPerformanceMeasure());
+		
+		if(builder.getUseCache()) {
+			return new CacheEvaluatorMeasureBridge(measure, builder.getDBAdapter());	
+		}else {
+			return new SimpleEvaluatorMeasureBridge(measure);
+		}
+		
 	}
 	
 	public WekaMLPlanWekaClassifier() throws IOException {

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/Util.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/Util.java
@@ -39,7 +39,7 @@ public class Util {
 		Classifier leftClassifier = AbstractClassifier.forName(experiment.getNameOfLeftClassifier(), null);
 		Classifier innerClassifier = AbstractClassifier.forName(experiment.getNameOfInnerClassifier(), null);
 		Classifier rightClassifier = AbstractClassifier.forName(experiment.getNameOfRightClassifier(), null);
-		Random splitRandomSource = new Random(seed);
+
 		RPNDSplitter splitter = new RPNDSplitter(new Random(seed), classifierForRPNDSplit);
 		
 		/* conduct experiments */
@@ -54,7 +54,7 @@ public class Util {
 			MCTreeNodeReD classifier = new MCTreeNodeReD(innerClassifier, classSplit.get(0), leftClassifier, classSplit.get(1), rightClassifier);
 			long start = System.currentTimeMillis();
 			Map<String, Object> result = new HashMap<>();
-			List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, splitRandomSource, .7f);
+			List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, seed + k, .7);
 			classifier.buildClassifier(dataSplit.get(0));
 			long time = System.currentTimeMillis() - start;
 			Evaluation eval = new Evaluation(dataSplit.get(0));
@@ -77,7 +77,6 @@ public class Util {
 		/* prepare basis for experiments */
 		int seed = experiment.getSeed();
 		String classifier = experiment.getNameOfClassifier();
-		Random splitRandomSource = new Random(seed);
 		RPNDSplitter splitter = new RPNDSplitter(new Random(seed), AbstractClassifier.forName(classifier, null));
 
 		/* conduct experiments */
@@ -87,7 +86,7 @@ public class Util {
 			Vote ensemble = new Vote();
 			ensemble.setOptions(new String[] {"-R", "MAJ"});
 			long start = System.currentTimeMillis();
-			List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, splitRandomSource, .7f);
+			List<Instances> dataSplit = WekaUtil.getStratifiedSplit(data, seed + k, .7);
 			for (int i = 0; i < experiment.getNumberOfStumps(); i++) {
 			
 				List<Collection<String>> classSplit;

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/ExperimentRunner.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/ExperimentRunner.java
@@ -7,18 +7,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-
-import org.nd4j.linalg.indexing.functions.Zero;
 
 import jaicore.ml.WekaUtil;
 import jaicore.ml.classification.multiclass.reduction.MCTreeNodeReD;
 import jaicore.ml.classification.multiclass.reduction.splitters.ISplitter;
 import jaicore.ml.classification.multiclass.reduction.splitters.ISplitterFactory;
-import jaicore.ml.core.evaluation.measure.singlelabel.MultiClassPerformanceMeasure;
 import jaicore.ml.core.evaluation.measure.singlelabel.ZeroOneLoss;
 import jaicore.ml.evaluation.evaluators.weka.FixedSplitClassifierEvaluator;
 import jaicore.ml.evaluation.evaluators.weka.MonteCarloCrossValidationEvaluator;
+import jaicore.ml.evaluation.evaluators.weka.SimpleEvaluatorMeasureBridge;
 import weka.classifiers.AbstractClassifier;
 import weka.classifiers.Classifier;
 import weka.core.Instances;
@@ -48,8 +45,8 @@ public class ExperimentRunner<T extends ISplitter> {
 		Classifier leftClassifier = AbstractClassifier.forName(experiment.getNameOfLeftClassifier(), null);
 		Classifier innerClassifier = AbstractClassifier.forName(experiment.getNameOfInnerClassifier(), null);
 		Classifier rightClassifier = AbstractClassifier.forName(experiment.getNameOfRightClassifier(), null);
-		List<Instances> outerSplit = WekaUtil.getStratifiedSplit(data, new Random(experiment.getSeed()), .7f);
-		MonteCarloCrossValidationEvaluator mccv = new MonteCarloCrossValidationEvaluator(new ZeroOneLoss(), mccvRepeats, outerSplit.get(0), .7f, seed);
+		List<Instances> outerSplit = WekaUtil.getStratifiedSplit(data, experiment.getSeed(), .7);
+		MonteCarloCrossValidationEvaluator mccv = new MonteCarloCrossValidationEvaluator(new SimpleEvaluatorMeasureBridge(new ZeroOneLoss()), mccvRepeats, outerSplit.get(0), .7, seed);
 		ISplitter splitter = splitterFactory.getSplitter(seed);
 		
 		/* compute best of k splits */

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/confusion/ConfusionBasedAlgorithm.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/confusion/ConfusionBasedAlgorithm.java
@@ -27,7 +27,7 @@ public class ConfusionBasedAlgorithm {
 		int numClasses = data.numClasses();
 		System.out.println("Computing confusion matrices ...");
 		for (int i = 0; i < 10; i++) {
-			List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(seed), .7f);
+			List<Instances> split = WekaUtil.getStratifiedSplit(data, seed, .7f);
 			// MulticlassEvaluator eval = new MulticlassEvaluator(new Random(seed));
 
 			/* compute confusion matrices for each classifier */
@@ -134,7 +134,7 @@ public class ConfusionBasedAlgorithm {
 			classMap.put(data.classAttribute().value(i2), "r");
 		}
 		Instances newData = WekaUtil.getRefactoredInstances(data, classMap);
-		List<Instances> binaryInnerSplit = WekaUtil.getStratifiedSplit(newData, new Random(seed), .7f);
+		List<Instances> binaryInnerSplit = WekaUtil.getStratifiedSplit(newData, seed, .7f);
 
 		/* now identify the classifier that can best separate these two clusters */
 		int leastSeenMistakes = Integer.MAX_VALUE;

--- a/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/confusion/ConfusionBasedGreedyOptimizingAlgorithm.java
+++ b/softwareconfiguration/mlplan/src/de/upb/crc901/reduction/single/confusion/ConfusionBasedGreedyOptimizingAlgorithm.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import jaicore.basic.sets.SetUtil;
@@ -22,7 +21,7 @@ public class ConfusionBasedGreedyOptimizingAlgorithm {
 
 		System.out.println("START: " + data.relationName());
 		int seed = 0;
-		List<Instances> split = WekaUtil.getStratifiedSplit(data, new Random(seed), .7f);
+		List<Instances> split = WekaUtil.getStratifiedSplit(data, seed, .7f);
 		// MulticlassEvaluator eval = new MulticlassEvaluator(new Random(seed));
 		int numClasses = data.numClasses();
 
@@ -113,7 +112,7 @@ public class ConfusionBasedGreedyOptimizingAlgorithm {
 				classMap.put(data.classAttribute().value(i2), "r");
 			}
 			Instances newData = WekaUtil.getRefactoredInstances(data, classMap);
-			List<Instances> binaryInnerSplit = WekaUtil.getStratifiedSplit(newData, new Random(seed), .7f);
+			List<Instances> binaryInnerSplit = WekaUtil.getStratifiedSplit(newData, seed, .7f);
 
 			/* now identify the classifier that can best separate these two clusters */
 			for (String classifier : pClassifierNames) {

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlpipeline_evaluation/.gitignore
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlpipeline_evaluation/.gitignore
@@ -1,0 +1,1 @@
+/PerformanceDBAdapterTest.java

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/JSONSerializationTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/JSONSerializationTest.java
@@ -1,0 +1,33 @@
+package de.upb.crc901.mlplan.test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hasco.model.ComponentInstance;
+import hasco.serialization.ComponentLoader;
+import hasco.serialization.HASCOJacksonModule;
+import junit.framework.Assert;
+
+public class JSONSerializationTest {
+
+	String oldPlainJson = "{\"component\": {\"name\": \"pipeline\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"pipeline\", \"MLPipeline\", \"AbstractClassifier\"], \"requiredInterfaces\": {\"classifier\": \"BaseClassifier\", \"preprocessor\": \"AbstractPreprocessor\"}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {\"classifier\": {\"component\": {\"name\": \"weka.classifiers.rules.ZeroR\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"weka.classifiers.rules.ZeroR\", \"AbstractClassifier\", \"WekaBaseClassifier\", \"BaseClassifier\"], \"requiredInterfaces\": {}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}, \"preprocessor\": {\"component\": {\"name\": \"weka.attributeSelection.AttributeSelection\", \"parameters\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.AttributeSelection\", \"AbstractPreprocessor\"], \"requiredInterfaces\": {\"eval\": \"evaluator\", \"search\": \"searcher\"}}, \"parameterValues\": {\"M\": \"false\"}, \"satisfactionOfRequiredInterfaces\": {\"eval\": {\"component\": {\"name\": \"weka.attributeSelection.SymmetricalUncertAttributeEval\", \"parameters\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.SymmetricalUncertAttributeEval\", \"evaluator\"], \"requiredInterfaces\": {}}, \"parameterValues\": {\"M\": \"true\"}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"parametersThatHaveNotBeenSetExplicitly\": []}, \"search\": {\"component\": {\"name\": \"weka.attributeSelection.Ranker\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.Ranker\", \"searcher\"], \"requiredInterfaces\": {}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}}, \"parametersThatHaveBeenSetExplicitly\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"parametersThatHaveNotBeenSetExplicitly\": []}}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}"; 
+			
+	@Test
+	public void testSerializeComponentInstance() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new HASCOJacksonModule());
+
+		try {
+			ComponentInstance instance = mapper.readValue(oldPlainJson, ComponentInstance.class);
+			System.out.println(instance);
+		} catch (IOException e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
+	}
+	
+}

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/JSONSerializationTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/JSONSerializationTest.java
@@ -1,6 +1,5 @@
 package de.upb.crc901.mlplan.test;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.junit.Test;
@@ -8,12 +7,16 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hasco.model.ComponentInstance;
-import hasco.serialization.ComponentLoader;
 import hasco.serialization.HASCOJacksonModule;
 import junit.framework.Assert;
-
+/**
+ * Tests the deserialization module for the {@link ComponentInstance} json serialization.
+ * @author elppa
+ *
+ */
 public class JSONSerializationTest {
 
+	/* ComponentInstance json string*/
 	String oldPlainJson = "{\"component\": {\"name\": \"pipeline\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"pipeline\", \"MLPipeline\", \"AbstractClassifier\"], \"requiredInterfaces\": {\"classifier\": \"BaseClassifier\", \"preprocessor\": \"AbstractPreprocessor\"}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {\"classifier\": {\"component\": {\"name\": \"weka.classifiers.rules.ZeroR\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"weka.classifiers.rules.ZeroR\", \"AbstractClassifier\", \"WekaBaseClassifier\", \"BaseClassifier\"], \"requiredInterfaces\": {}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}, \"preprocessor\": {\"component\": {\"name\": \"weka.attributeSelection.AttributeSelection\", \"parameters\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.AttributeSelection\", \"AbstractPreprocessor\"], \"requiredInterfaces\": {\"eval\": \"evaluator\", \"search\": \"searcher\"}}, \"parameterValues\": {\"M\": \"false\"}, \"satisfactionOfRequiredInterfaces\": {\"eval\": {\"component\": {\"name\": \"weka.attributeSelection.SymmetricalUncertAttributeEval\", \"parameters\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.SymmetricalUncertAttributeEval\", \"evaluator\"], \"requiredInterfaces\": {}}, \"parameterValues\": {\"M\": \"true\"}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"parametersThatHaveNotBeenSetExplicitly\": []}, \"search\": {\"component\": {\"name\": \"weka.attributeSelection.Ranker\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"weka.attributeSelection.Ranker\", \"searcher\"], \"requiredInterfaces\": {}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}}, \"parametersThatHaveBeenSetExplicitly\": [{\"name\": \"M\", \"numeric\": false, \"categorical\": true, \"defaultValue\": true, \"defaultDomain\": {\"values\": [\"true\", \"false\"]}}], \"parametersThatHaveNotBeenSetExplicitly\": []}}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}"; 
 			
 	@Test

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/CacheTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/CacheTest.java
@@ -15,56 +15,62 @@ import jaicore.ml.WekaUtil;
 import jaicore.ml.cache.ReproducibleInstances;
 import weka.core.Instances;
 
+/**
+ * Tests the functionality of {@link ReproducibleInstances}, by creating one an
+ * using its history to recreate it. Fails if these two are not the same.
+ * 
+ * @author jnowack
+ */
 public class CacheTest {
 
 	@Test
 	public void testGetStratifiedSplit() {
 		try {
-			
-		OpenmlConnector connector = new OpenmlConnector();
-		DataSetDescription ds = connector.dataGet(40983);
-		File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
-		Instances data = new Instances(new BufferedReader(new FileReader(file)));
-		data.setClassIndex(data.numAttributes() - 1);
 
-		// perform a split with normal instances
-		Instances i = WekaUtil.getStratifiedSplit(data, 45, 0.7).get(0);
-		
-		
-		//
-		ReproducibleInstances rData = ReproducibleInstances.fromOpenML("40983", "4350e421cdc16404033ef1812ea38c01");
-		
-		// perform a split
-		ReproducibleInstances ri0 = WekaUtil.getStratifiedSplit(rData, new Random(45), 0.1).get(0);
-		
-		// perform a split
-		Instances ri1 = WekaUtil.getStratifiedSplit((Instances)rData, 45, 0.1).get(0);
-		
-		if(ri0.getInstructions().size() != 2) {
-			fail("wrong number of instructions");
-		}
-		if(((ReproducibleInstances)ri1).getInstructions().size() != 2) {
-			fail("wrong number of instructions");
-		}
-		
-		// test reproduction
-		ReproducibleInstances r = ReproducibleInstances.fromHistory(ri0.getInstructions(), "4350e421cdc16404033ef1812ea38c01");
-		
-		if(ri0.size() != r.size()) {
-			fail("wrong number of instructions");
-		}
-		
-		for (int j = 0; j < r.size(); j++) {
-			if(!ri0.get(j).toString().equals(r.get(j).toString())) { // Instances in Weka do not implement equals!
-				fail("Reproduction failed");
+			OpenmlConnector connector = new OpenmlConnector();
+			DataSetDescription ds = connector.dataGet(40983);
+			File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
+			Instances data = new Instances(new BufferedReader(new FileReader(file)));
+			data.setClassIndex(data.numAttributes() - 1);
+
+			// perform a split with normal instances
+			Instances i = WekaUtil.getStratifiedSplit(data, 45, 0.7).get(0);
+
+			//
+			ReproducibleInstances rData = ReproducibleInstances.fromOpenML("40983", "4350e421cdc16404033ef1812ea38c01");
+
+			// perform a split
+			ReproducibleInstances ri0 = WekaUtil.getStratifiedSplit(rData, new Random(45), 0.1).get(0);
+
+			// perform a split
+			Instances ri1 = WekaUtil.getStratifiedSplit((Instances) rData, 45, 0.1).get(0);
+
+			if (ri0.getInstructions().size() != 2) {
+				fail("wrong number of instructions");
 			}
-		}
-		
+			if (((ReproducibleInstances) ri1).getInstructions().size() != 2) {
+				fail("wrong number of instructions");
+			}
+
+			// test reproduction
+			ReproducibleInstances r = ReproducibleInstances.fromHistory(ri0.getInstructions(),
+					"4350e421cdc16404033ef1812ea38c01");
+
+			if (ri0.size() != r.size()) {
+				fail("wrong number of instructions");
+			}
+
+			for (int j = 0; j < r.size(); j++) {
+				if (!ri0.get(j).toString().equals(r.get(j).toString())) { // Instances in Weka do not implement equals!
+					fail("Reproduction failed");
+				}
+			}
+
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
-		
+
 	}
 
 }

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/CacheTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/CacheTest.java
@@ -1,0 +1,70 @@
+package de.upb.crc901.mlplan.test.cache;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Random;
+
+import org.junit.Test;
+import org.openml.apiconnector.io.OpenmlConnector;
+import org.openml.apiconnector.xml.DataSetDescription;
+
+import jaicore.ml.WekaUtil;
+import jaicore.ml.cache.ReproducibleInstances;
+import weka.core.Instances;
+
+public class CacheTest {
+
+	@Test
+	public void testGetStratifiedSplit() {
+		try {
+			
+		OpenmlConnector connector = new OpenmlConnector();
+		DataSetDescription ds = connector.dataGet(40983);
+		File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
+		Instances data = new Instances(new BufferedReader(new FileReader(file)));
+		data.setClassIndex(data.numAttributes() - 1);
+
+		// perform a split with normal instances
+		Instances i = WekaUtil.getStratifiedSplit(data, 45, 0.7).get(0);
+		
+		
+		//
+		ReproducibleInstances rData = ReproducibleInstances.fromOpenML("40983", "4350e421cdc16404033ef1812ea38c01");
+		
+		// perform a split
+		ReproducibleInstances ri0 = WekaUtil.getStratifiedSplit(rData, new Random(45), 0.1).get(0);
+		
+		// perform a split
+		Instances ri1 = WekaUtil.getStratifiedSplit((Instances)rData, 45, 0.1).get(0);
+		
+		if(ri0.getInstructions().size() != 2) {
+			fail("wrong number of instructions");
+		}
+		if(((ReproducibleInstances)ri1).getInstructions().size() != 2) {
+			fail("wrong number of instructions");
+		}
+		
+		// test reproduction
+		ReproducibleInstances r = ReproducibleInstances.fromHistory(ri0.getInstructions(), "4350e421cdc16404033ef1812ea38c01");
+		
+		if(ri0.size() != r.size()) {
+			fail("wrong number of instructions");
+		}
+		
+		for (int j = 0; j < r.size(); j++) {
+			if(!ri0.get(j).toString().equals(r.get(j).toString())) { // Instances in Weka do not implement equals!
+				fail("Reproduction failed");
+			}
+		}
+		
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		
+	}
+
+}

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/PerformanceDBAdapterTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/PerformanceDBAdapterTest.java
@@ -24,6 +24,12 @@ import weka.attributeSelection.Ranker;
 import weka.classifiers.functions.MultilayerPerceptron;
 import weka.classifiers.trees.RandomForest;
 
+/**
+ * Tests the funcionality of the {@link PerformanceDBAdapter}. Tries to save and load different performance values.
+ * 
+ * @author jmhansel
+ *
+ */
 public class PerformanceDBAdapterTest {
 	@Test
 	public void test() {

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/PerformanceDBAdapterTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/PerformanceDBAdapterTest.java
@@ -1,0 +1,84 @@
+package de.upb.crc901.mlplan.test.cache;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import de.upb.crc901.mlpipeline_evaluation.PerformanceDBAdapter;
+import de.upb.crc901.mlplan.multiclass.wekamlplan.weka.MLPipelineComponentInstanceFactory;
+import de.upb.crc901.mlplan.multiclass.wekamlplan.weka.model.MLPipeline;
+import hasco.model.ComponentInstance;
+import hasco.serialization.ComponentLoader;
+import jaicore.basic.SQLAdapter;
+import jaicore.ml.WekaUtil;
+import jaicore.ml.cache.ReproducibleInstances;
+import jaicore.ml.core.evaluation.measure.multilabel.F1AverageMeasure;
+import jaicore.ml.core.evaluation.measure.singlelabel.ZeroOneLoss;
+import weka.attributeSelection.OneRAttributeEval;
+import weka.attributeSelection.Ranker;
+import weka.classifiers.functions.MultilayerPerceptron;
+import weka.classifiers.trees.RandomForest;
+
+public class PerformanceDBAdapterTest {
+	@Test
+	public void test() {
+		SQLAdapter adapter = new SQLAdapter("host", "user", "password", "database");
+		PerformanceDBAdapter pAdapter = new PerformanceDBAdapter(adapter, "performance_cache_test");
+		try {
+			ComponentLoader loader = new ComponentLoader(
+					new File("conf/automl/searchmodels/weka/weka-all-autoweka.json"));
+			MLPipelineComponentInstanceFactory factory = new MLPipelineComponentInstanceFactory(loader.getComponents());
+			ComponentInstance composition1 = factory.convertToComponentInstance(
+					new MLPipeline(new Ranker(), new OneRAttributeEval(), new RandomForest()));
+
+			ReproducibleInstances reproducibleInstances1 = ReproducibleInstances.fromOpenML("40983",
+					"4350e421cdc16404033ef1812ea38c01");
+			List<ReproducibleInstances> instances1 = WekaUtil.getStratifiedSplit(reproducibleInstances1, 5, 0.7, 0.3);
+			String className1 = ZeroOneLoss.class.getName();
+			double score = Math.PI / 5.0;
+
+			// Store the first sample
+			pAdapter.store(composition1, instances1.get(0), instances1.get(1), score, className1, 6517L);
+
+			// These should have no entry in the db, assuming it was empty when the test was
+			// started
+			ComponentInstance composition2 = factory.convertToComponentInstance(
+					new MLPipeline(new Ranker(), new OneRAttributeEval(), new MultilayerPerceptron()));
+			ReproducibleInstances reproducibleInstances2 = ReproducibleInstances.fromOpenML("181",
+					"4350e421cdc16404033ef1812ea38c01");
+			List<ReproducibleInstances> instances2 = WekaUtil.getStratifiedSplit(reproducibleInstances2, 5, 0.7, 0.3);
+			List<ReproducibleInstances> instances3 = WekaUtil.getStratifiedSplit(reproducibleInstances1, 4, 0.7, 0.3);
+			String className2 = F1AverageMeasure.class.getName();
+
+			// This is a different dataset
+			Optional<Double> shouldntExist1 = pAdapter.exists(composition1, instances2.get(0), instances2.get(1),
+					className1);
+			// This is a different is a different seed for splitting
+			Optional<Double> shouldntExist2 = pAdapter.exists(composition1, instances3.get(0), instances3.get(1),
+					className1);
+			// This is a different composition
+			Optional<Double> shouldntExist3 = pAdapter.exists(composition2, instances1.get(0), instances1.get(1),
+					className1);
+			// This is a different loss function (or measure resp.)
+			Optional<Double> shouldntExist4 = pAdapter.exists(composition1, instances1.get(0), instances1.get(1),
+					className2);
+			// This is the entry we inserted above
+			Optional<Double> shouldExist1 = pAdapter.exists(composition1, instances1.get(0), instances1.get(1),
+					className1);
+
+			assertFalse(shouldntExist1.isPresent());
+			assertFalse(shouldntExist2.isPresent());
+			assertFalse(shouldntExist3.isPresent());
+			assertFalse(shouldntExist4.isPresent());
+			assertTrue(shouldExist1.isPresent());
+			pAdapter.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/ReproducabilityTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/ReproducabilityTest.java
@@ -16,6 +16,12 @@ import jaicore.ml.cache.ReproducibleInstances;
 import jaicore.ml.core.evaluation.measure.singlelabel.ZeroOneLoss;
 import weka.classifiers.Classifier;
 
+/**
+ * Test to ensure that saved {@link ReproducibleInstances} and Solutions can be reproduced and create the same performance value every time.
+ * 
+ * @author jmhansel
+ *
+ */
 public class ReproducabilityTest {
 
 	@Test

--- a/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/ReproducabilityTest.java
+++ b/softwareconfiguration/mlplan/test/de/upb/crc901/mlplan/test/cache/ReproducabilityTest.java
@@ -1,0 +1,52 @@
+package de.upb.crc901.mlplan.test.cache;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.upb.crc901.mlpipeline_evaluation.CacheEvaluatorMeasureBridge;
+import de.upb.crc901.mlplan.multiclass.wekamlplan.weka.WEKAPipelineFactory;
+import hasco.model.ComponentInstance;
+import hasco.serialization.HASCOJacksonModule;
+import jaicore.ml.cache.Instruction;
+import jaicore.ml.cache.ReproducibleInstances;
+import jaicore.ml.core.evaluation.measure.singlelabel.ZeroOneLoss;
+import weka.classifiers.Classifier;
+
+public class ReproducabilityTest {
+
+	@Test
+	public void test() {
+		String trainJson = "[{\"inputs\": {\"id\": \"40983\", \"provider\": \"openml.org\"}, \"command\": \"loadDataset\"}, {\"inputs\": {\"seed\": \"-4962768465676381896\", \"ratios\": \"[0.7]\", \"outIndex\": \"0\"}, \"command\": \"split\"}, {\"inputs\": {\"seed\": \"0\", \"ratios\": \"[0.3]\", \"outIndex\": \"1\"}, \"command\": \"split\"}, {\"inputs\": {\"seed\": \"1534718591\", \"ratios\": \"[0.7]\", \"outIndex\": \"0\"}, \"command\": \"split\"}]";
+		String validationJson = "[{\"inputs\": {\"id\": \"40983\", \"provider\": \"openml.org\"}, \"command\": \"loadDataset\"}, {\"inputs\": {\"seed\": \"-4962768465676381896\", \"ratios\": \"[0.7]\", \"outIndex\": \"0\"}, \"command\": \"split\"}, {\"inputs\": {\"seed\": \"0\", \"ratios\": \"[0.3]\", \"outIndex\": \"1\"}, \"command\": \"split\"}, {\"inputs\": {\"seed\": \"1534718591\", \"ratios\": \"[0.7]\", \"outIndex\": \"1\"}, \"command\": \"split\"}]";
+		String compositionJson = "{\"component\": {\"name\": \"weka.classifiers.bayes.NaiveBayesMultinomial\", \"parameters\": [], \"dependencies\": [], \"providedInterfaces\": [\"weka.classifiers.bayes.NaiveBayesMultinomial\", \"AbstractClassifier\", \"WekaBaseClassifier\", \"BaseClassifier\"], \"requiredInterfaces\": {}}, \"parameterValues\": {}, \"satisfactionOfRequiredInterfaces\": {}, \"parametersThatHaveBeenSetExplicitly\": [], \"parametersThatHaveNotBeenSetExplicitly\": []}";
+		
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new HASCOJacksonModule());
+		
+		try {
+			List<Instruction> trainHistory = mapper.readValue(trainJson, new TypeReference<List<Instruction>>(){});
+			List<Instruction> validationHistory = mapper.readValue(validationJson, new TypeReference<List<Instruction>>(){});
+			ComponentInstance composition = mapper.readValue(compositionJson, ComponentInstance.class);
+			ReproducibleInstances trainInstances = ReproducibleInstances.fromHistory(trainHistory, "4350e421cdc16404033ef1812ea38c01");
+			ReproducibleInstances validationInstances = ReproducibleInstances.fromHistory(validationHistory, "4350e421cdc16404033ef1812ea38c01");
+			ZeroOneLoss basicEvaluator = new ZeroOneLoss();
+			CacheEvaluatorMeasureBridge bridge = new CacheEvaluatorMeasureBridge(basicEvaluator, null);
+			trainInstances.setCacheLookup(false);
+			validationInstances.setCacheLookup(false);
+			trainInstances.setCacheStorage(false);
+			validationInstances.setCacheStorage(false);
+			WEKAPipelineFactory factory = new WEKAPipelineFactory();
+			Classifier pipeline = factory.getComponentInstantiation(composition);
+			Double score = bridge.evaluateSplit(pipeline, trainInstances, validationInstances);
+			System.out.println(score);
+			
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
ReproducibleInstances are new Instances which can be used to track the creation of Instances by saving the origin and splits.
Added intermediate result cache. Computed loss values can be stored in a database now. See CacheEvaluatorMeasureBridge.
The Cache can be used to store results and later reproduce them or to also use cached results in the search.
If a normal Instances Object is used the cache is not activated. Flags to control the use of the cache can be set in the ReproducibleInstances.