### PR TITLE
Bug regarding hashCode of DenseDoubleVector

### DIFF
--- a/JAICore/jaicore-math/src/main/java/de/upb/isys/linearalgebra/DenseDoubleVector.java
+++ b/JAICore/jaicore-math/src/main/java/de/upb/isys/linearalgebra/DenseDoubleVector.java
@@ -195,12 +195,4 @@ public class DenseDoubleVector extends AbstractVector {
 		return new SparseDoubleVector(asArray());
 	}
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((internalVector == null) ? 0 : internalVector.hashCode());
-		return result;
-	}
-
 }


### PR DESCRIPTION
The current hashCode method calls the hashCode method of the internal no.uib.cipr.matrix.DenseVector. Unfortunately, this class does not overwrite the hashCode method ( https://github.com/fommil/matrix-toolkits-java/blob/master/src/main/java/no/uib/cipr/matrix/DenseVector.java ) , thus the hashCode method of Object is called. As an effect, two different Objects that represent identical vectors are being hashed onto different values, HashSets and HashMaps don't work as expected. As a fix I propose not overwriting hashCode in this class, such that hashCode of AbstractVector is called, which works fine for now.