### PR TITLE
Fixed problem of vanishing preferred node evaluator.

### DIFF
--- a/JAICore/jaicore-search/src/main/java/jaicore/search/algorithms/standard/bestfirst/StandardBestFirstFactory.java
+++ b/JAICore/jaicore-search/src/main/java/jaicore/search/algorithms/standard/bestfirst/StandardBestFirstFactory.java
@@ -1,46 +1,60 @@
 package jaicore.search.algorithms.standard.bestfirst;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import jaicore.logging.ToJSONStringUtil;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.AlternativeNodeEvaluator;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.INodeEvaluator;
 import jaicore.search.core.interfaces.GraphGenerator;
 import jaicore.search.probleminputs.GraphSearchWithSubpathEvaluationsInput;
 
 public class StandardBestFirstFactory<N, A, V extends Comparable<V>> extends BestFirstFactory<GraphSearchWithSubpathEvaluationsInput<N, A, V>, N, A, V> {
-	
+
 	private INodeEvaluator<N, V> preferredNodeEvaluator;
-	
-	public void setNodeEvaluator(INodeEvaluator<N, V> nodeEvaluator) {
-		setProblemInput(new GraphSearchWithSubpathEvaluationsInput<>(getInput() != null ? getInput().getGraphGenerator() : null, nodeEvaluator));
+
+	public void setNodeEvaluator(final INodeEvaluator<N, V> nodeEvaluator) {
+		this.setProblemInput(new GraphSearchWithSubpathEvaluationsInput<>(this.getInput() != null ? this.getInput().getGraphGenerator() : null, nodeEvaluator));
 	}
 
-	public void setGraphGenerator(GraphGenerator<N, A> graphGenerator) {
-		setProblemInput(new GraphSearchWithSubpathEvaluationsInput<>(graphGenerator, getInput() != null ? getInput().getNodeEvaluator() : null));
+	public void setGraphGenerator(final GraphGenerator<N, A> graphGenerator) {
+		this.setProblemInput(new GraphSearchWithSubpathEvaluationsInput<>(graphGenerator, this.getInput() != null ? this.getInput().getNodeEvaluator() : null));
 	}
 
 	public INodeEvaluator<N, V> getPreferredNodeEvaluator() {
-		return preferredNodeEvaluator;
+		return this.preferredNodeEvaluator;
 	}
 
-	public void setPreferredNodeEvaluator(INodeEvaluator<N, V> preferredNodeEvaluator) {
+	public void setPreferredNodeEvaluator(final INodeEvaluator<N, V> preferredNodeEvaluator) {
 		this.preferredNodeEvaluator = preferredNodeEvaluator;
 	}
-	
+
 	@Override
 	public BestFirst<GraphSearchWithSubpathEvaluationsInput<N, A, V>, N, A, V> getAlgorithm() {
-		if (getInput().getGraphGenerator() == null)
+		if (this.getInput().getGraphGenerator() == null) {
 			throw new IllegalStateException("Cannot produce BestFirst searches before the graph generator is set in the problem.");
-		if (getInput().getNodeEvaluator() == null)
+		}
+		if (this.getInput().getNodeEvaluator() == null) {
 			throw new IllegalStateException("Cannot produce BestFirst searches before the node evaluator is set.");
-		
+		}
+
 		/* determine search problem */
-		GraphSearchWithSubpathEvaluationsInput<N, A, V> problem = getInput();
-		if (preferredNodeEvaluator != null) {
-			problem = new GraphSearchWithSubpathEvaluationsInput<N, A, V>(problem.getGraphGenerator(), new AlternativeNodeEvaluator<>(preferredNodeEvaluator, problem.getNodeEvaluator()));
+		GraphSearchWithSubpathEvaluationsInput<N, A, V> problem = this.getInput();
+		if (this.preferredNodeEvaluator != null) {
+			problem = new GraphSearchWithSubpathEvaluationsInput<N, A, V>(problem.getGraphGenerator(), new AlternativeNodeEvaluator<>(this.preferredNodeEvaluator, problem.getNodeEvaluator()));
 		}
 		BestFirst<GraphSearchWithSubpathEvaluationsInput<N, A, V>, N, A, V> search = new BestFirst<>(problem);
-		search.setTimeoutForComputationOfF(getTimeoutForFInMS(), getTimeoutEvaluator());
-		if (getLoggerName() != null && getLoggerName().length() > 0)
-			search.setLoggerName(getLoggerName());
+		search.setTimeoutForComputationOfF(this.getTimeoutForFInMS(), this.getTimeoutEvaluator());
+		if (this.getLoggerName() != null && this.getLoggerName().length() > 0) {
+			search.setLoggerName(this.getLoggerName());
+		}
 		return search;
+	}
+
+	@Override
+	public String toString() {
+		Map<String, Object> fields = new HashMap<>();
+		fields.put("preferredNodeEvaluator", this.preferredNodeEvaluator);
+		return ToJSONStringUtil.toJSONString(this.getClass().getSimpleName(), fields);
 	}
 }

--- a/JAICore/jaicore-search/src/main/java/jaicore/search/problemtransformers/GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTransformerViaRDFS.java
+++ b/JAICore/jaicore-search/src/main/java/jaicore/search/problemtransformers/GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTransformerViaRDFS.java
@@ -3,6 +3,7 @@ package jaicore.search.problemtransformers;
 import java.util.Random;
 import java.util.function.Predicate;
 
+import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.AlternativeNodeEvaluator;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.INodeEvaluator;
 import jaicore.search.algorithms.standard.bestfirst.nodeevaluation.RandomCompletionBasedNodeEvaluator;
 import jaicore.search.probleminputs.GraphSearchWithPathEvaluationsInput;
@@ -17,7 +18,8 @@ public class GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTrans
 	private final int timeoutForSingleCompletionEvaluationInMS;
 	private final int timeoutForNodeEvaluationInMS;
 
-	public GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTransformerViaRDFS(INodeEvaluator<N, V> preferredNodeEvaluator, Predicate<N> preferredNodeEvaluatorForRandomCompletion, int seed, int numSamples, int timeoutForSingleCompletionEvaluationInMS, int timeoutForNodeEvaluationInMS) {
+	public GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTransformerViaRDFS(final INodeEvaluator<N, V> preferredNodeEvaluator, final Predicate<N> preferredNodeEvaluatorForRandomCompletion, final int seed,
+			final int numSamples, final int timeoutForSingleCompletionEvaluationInMS, final int timeoutForNodeEvaluationInMS) {
 		super();
 		if (numSamples <= 0) {
 			throw new IllegalArgumentException("Sample size has been set to " + numSamples + " but must be strictly positive!");
@@ -31,24 +33,30 @@ public class GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTrans
 	}
 
 	public INodeEvaluator<N, V> getPreferredNodeEvaluator() {
-		return preferredNodeEvaluator;
+		return this.preferredNodeEvaluator;
 	}
 
 	public Predicate<N> getPrioritizedNodePredicatesForRandomCompletion() {
-		return prioritizedNodesInRandomCompletion;
+		return this.prioritizedNodesInRandomCompletion;
 	}
 
 	public int getSeed() {
-		return seed;
+		return this.seed;
 	}
 
 	public int getNumSamples() {
-		return numSamples;
+		return this.numSamples;
 	}
 
 	@Override
-	public GraphSearchWithSubpathEvaluationsInput<N, A, V> transform(GraphSearchWithPathEvaluationsInput<N, A, V> problem) {
-		setNodeEvaluator(new RandomCompletionBasedNodeEvaluator<>(new Random(seed), numSamples, problem.getPathEvaluator(), timeoutForSingleCompletionEvaluationInMS, timeoutForNodeEvaluationInMS, prioritizedNodesInRandomCompletion));
+	public GraphSearchWithSubpathEvaluationsInput<N, A, V> transform(final GraphSearchWithPathEvaluationsInput<N, A, V> problem) {
+		RandomCompletionBasedNodeEvaluator<N, V> rdfsNodeEvaluator = new RandomCompletionBasedNodeEvaluator<>(new Random(this.seed), this.numSamples, problem.getPathEvaluator(), this.timeoutForSingleCompletionEvaluationInMS,
+				this.timeoutForNodeEvaluationInMS, this.prioritizedNodesInRandomCompletion);
+		if (this.preferredNodeEvaluator != null) {
+			this.setNodeEvaluator(new AlternativeNodeEvaluator<>(this.preferredNodeEvaluator, rdfsNodeEvaluator));
+		} else {
+			this.setNodeEvaluator(rdfsNodeEvaluator);
+		}
 		return super.transform(problem);
 	}
 

--- a/softwareconfiguration/hasco/src/examples/java/hasco/examples/HASCOModelStatisticsObserverPluginExample.java
+++ b/softwareconfiguration/hasco/src/examples/java/hasco/examples/HASCOModelStatisticsObserverPluginExample.java
@@ -14,23 +14,22 @@ import jaicore.basic.algorithm.AlgorithmExecutionCanceledException;
 import jaicore.basic.algorithm.exceptions.AlgorithmException;
 import jaicore.graphvisualizer.plugin.graphview.GraphViewPlugin;
 import jaicore.graphvisualizer.plugin.nodeinfo.NodeInfoGUIPlugin;
-import jaicore.graphvisualizer.window.GraphVisualizationWindow;
+import jaicore.graphvisualizer.window.AlgorithmVisualizationWindow;
 import jaicore.planning.hierarchical.algorithms.forwarddecomposition.graphgenerators.tfd.TFDNodeInfoGenerator;
 import jaicore.search.model.travesaltree.JaicoreNodeInfoGenerator;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 
 public class HASCOModelStatisticsObserverPluginExample {
-	public static void main(String[] args) throws UnresolvableRequiredInterfaceException, IOException, InterruptedException, AlgorithmExecutionCanceledException, TimeoutException, AlgorithmException {
+	public static void main(final String[] args) throws UnresolvableRequiredInterfaceException, IOException, InterruptedException, AlgorithmExecutionCanceledException, TimeoutException, AlgorithmException {
 		HASCOViaFDAndBestFirstFactory<Double> hascoFactory = new HASCOViaFDAndBestFirstFactory<>(n -> 0.0);
 		Random r = new Random();
-//		hascoFactory.setProblemInput(new RefinementConfiguredSoftwareConfigurationProblem<>(new File("testrsc/simpleproblemwithtwocomponents.json"), "IFace", n -> System.currentTimeMillis() * 1.0));
+		// hascoFactory.setProblemInput(new RefinementConfiguredSoftwareConfigurationProblem<>(new File("testrsc/simpleproblemwithtwocomponents.json"), "IFace", n -> System.currentTimeMillis() * 1.0));
 		hascoFactory.setProblemInput(new RefinementConfiguredSoftwareConfigurationProblem<>(new File("testrsc/mediumrecursiveproblem.json"), "IFace", n -> r.nextDouble()));
 		HASCOViaFDAndBestFirst<Double> hasco = hascoFactory.getAlgorithm();
 		hasco.setNumCPUs(1);
 		new JFXPanel();
-		Platform.runLater(new GraphVisualizationWindow(hasco, new GraphViewPlugin(), new NodeInfoGUIPlugin<>(new JaicoreNodeInfoGenerator<>(new TFDNodeInfoGenerator())), new HASCOModelStatisticsPlugin()));
+		Platform.runLater(new AlgorithmVisualizationWindow(hasco, new GraphViewPlugin(), new NodeInfoGUIPlugin<>(new JaicoreNodeInfoGenerator<>(new TFDNodeInfoGenerator())), new HASCOModelStatisticsPlugin()));
 		hasco.call();
 	}
 }
-

--- a/softwareconfiguration/mlplan/src/examples/java/de/upb/crc901/mlplan/examples/MLPlanARFFExample.java
+++ b/softwareconfiguration/mlplan/src/examples/java/de/upb/crc901/mlplan/examples/MLPlanARFFExample.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 
 import de.upb.crc901.mlplan.core.MLPlan;
@@ -12,6 +11,7 @@ import de.upb.crc901.mlplan.core.MLPlanBuilder;
 import de.upb.crc901.mlplan.gui.outofsampleplots.OutOfSampleErrorPlotPlugin;
 import de.upb.crc901.mlplan.multiclass.wekamlplan.weka.model.MLPipeline;
 import hasco.gui.statsplugin.HASCOModelStatisticsPlugin;
+import jaicore.basic.TimeOut;
 import jaicore.graphvisualizer.plugin.graphview.GraphViewPlugin;
 import jaicore.graphvisualizer.plugin.nodeinfo.NodeInfoGUIPlugin;
 import jaicore.graphvisualizer.plugin.solutionperformanceplotter.SolutionPerformanceTimelinePlugin;
@@ -48,7 +48,8 @@ public class MLPlanARFFExample {
 		mlplan.setNumCPUs(6);
 
 		new JFXPanel();
-		GraphVisualizationWindow window = new GraphVisualizationWindow(mlplan, new GraphViewPlugin(), new NodeInfoGUIPlugin<>(new JaicoreNodeInfoGenerator<>(new TFDNodeInfoGenerator())), new SearchRolloutHistogramPlugin<>(), new SolutionPerformanceTimelinePlugin(), new HASCOModelStatisticsPlugin(), new OutOfSampleErrorPlotPlugin(split.get(0), split.get(1)));
+		AlgorithmVisualizationWindow window = new AlgorithmVisualizationWindow(mlplan, new GraphViewPlugin(), new NodeInfoGUIPlugin<>(new JaicoreNodeInfoGenerator<>(new TFDNodeInfoGenerator())), new SearchRolloutHistogramPlugin<>(),
+				new SolutionPerformanceTimelinePlugin(), new HASCOModelStatisticsPlugin(), new OutOfSampleErrorPlotPlugin(split.get(0), split.get(1)));
 		Platform.runLater(window);
 
 		try {


### PR DESCRIPTION
There was a problem in HASCO when instantiated with random completions that if a preferred node evaluator was passed a constructor argument, it was simply ignored. Thus, configuring a custom preferred node evaluator had no effect at all.

Main changes are in GraphSearchProblemInputToGraphSearchWithSubpathEvaluationInputTransformerViaRDFS.java

Other stuff concerns fixing compile errors and adding some toString representation in JSON format for debugging.