### PR TITLE
Remove Dependencies to Other Repositories Than Maven Central

### DIFF
--- a/JAICore/jaicore-ml/build.gradle
+++ b/JAICore/jaicore-ml/build.gradle
@@ -7,31 +7,31 @@ dependencies {
 	compile project(":JAICore:jaicore-math")
 	testCompile project(path: ':JAICore:jaicore-basic', configuration: 'testArtifacts')
 	
-	compile group: 'org.openml', name: 'apiconnector', version: '1.0.16'
-	compile group: 'de.upb.isys', name: 'omlwebapp', version: '0.0.1'
-	compile ('de.upb.isys:meka:0.0.4') 
+	// openml
+	compile 'org.openml:apiconnector:1.0.16'
+    compile ('org.openml:EvaluationEngine:0.1.0') {
+    	exclude module: 'weka-stable'
+    }
+
+    
     compile group: 'edu.stanford.nlp', name: 'stanford-corenlp', version: '1.3.0'
 
 	
+	compile ('ai.libs.thirdparty:interruptible-meka:0.1.0')
+	compile ('net.sf.meka.thirdparty:mulan:1.4.0')
+	 
 	// dependencies for meka
-	compile group: 'org.kramerlab', name: 'bmad', version: '2.4'
-	compile group: 'gov.nist.math', name: 'jama', version: '1.0.3'
-	compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.1'
-	compile group: 'org.markdownj', name: 'markdownj', version: '0.3.0-1.0.2b4'
-	compile group: 'net.sf.meka.thirdparty', name: 'mst', version: '4.0'
+	compile 'org.kramerlab:bmad:2.4'
+	compile 'gov.nist.math:jama:1.0.3'
+	compile 'net.sf.trove4j:trove4j:3.0.1'
+	compile 'org.markdownj:markdownj:0.3.0-1.0.2b4'
+	compile 'net.sf.meka.thirdparty:mst:4.0'
 	
 	// weka requiring projects
 	compile group: 'org.kramerlab', name: 'autoencoder', version: '0.1'
 	compile group: 'com.github.fracpete', name: 'multisearch-weka-package', version: '2017.10.1'
 	
-	compile ('net.sf.meka.thirdparty:mulan:1.4.0')
 	
-	// deep learning
-	compile "org.deeplearning4j:deeplearning4j-core:1.0.0-beta3"
-	
-	// linear algebra
-  compile "org.nd4j:nd4j-native-platform:1.0.0-beta3"
-
 	// end dependencies for meka
 	
 	// weka dependencies
@@ -46,7 +46,7 @@ dependencies {
 	
 	
     // d4j dependencies: https://deeplearning4j.org/docs/latest/deeplearning4j-config-buildtools
-    compile "org.deeplearning4j:deeplearning4j-core:1.0.0-beta3"
+	compile "org.deeplearning4j:deeplearning4j-core:1.0.0-beta3"
     compile "org.nd4j:nd4j-native-platform:1.0.0-beta3"
 	
 	//JTwig template engine

--- a/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/latex/LatexDatasetTableGenerator.java
+++ b/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/latex/LatexDatasetTableGenerator.java
@@ -45,7 +45,7 @@ public class LatexDatasetTableGenerator {
 		OpenmlConnector client = new OpenmlConnector();
 		for (int id : datasetIds) {
 			DataSetDescription description = client.dataGet(id);
-			File file = description.getDataset("key");
+			File file = client.datasetGet(description);
 			this.datasets.add(new DataSource(file.getCanonicalPath()));
 		}
 	}

--- a/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/metafeatures/GlobalCharacterizer.java
+++ b/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/metafeatures/GlobalCharacterizer.java
@@ -14,7 +14,6 @@ import org.openml.webapplication.fantail.dc.statistical.Cardinality;
 import org.openml.webapplication.fantail.dc.statistical.NominalAttDistinctValues;
 import org.openml.webapplication.fantail.dc.statistical.SimpleMetaFeatures;
 import org.openml.webapplication.fantail.dc.statistical.Statistical;
-import org.openml.webapplication.features.GlobalMetafeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +90,7 @@ public class GlobalCharacterizer extends Characterizer {
 			try {
 				watch.reset();
 				watch.start();
-				metaFeatures.putAll(characterizer.characterize(instances));
+				metaFeatures.putAll(characterizer.characterizeAll(instances));
 				watch.stop();
 				computationTimes.put(characterizer.toString(), (double) watch.getTime());
 			} catch (Exception e) {

--- a/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/openml/OpenMLHelper.java
+++ b/JAICore/jaicore-ml/src/main/java/ai/libs/jaicore/ml/openml/OpenMLHelper.java
@@ -68,7 +68,7 @@ public class OpenMLHelper {
 		OpenmlConnector client = new OpenmlConnector();
 		try {
 			DataSetDescription description = client.dataGet(dataId);
-			File file = description.getDataset(OpenMLHelper.apiKey);
+			File file = client.datasetGet(description);
 			// Instances convert
 			return new DataSource(file.getCanonicalPath());
 		} catch (Exception e) {

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/core/dataset/sampling/infile/GeneralFileSamplingTester.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/core/dataset/sampling/infile/GeneralFileSamplingTester.java
@@ -144,14 +144,14 @@ public abstract class GeneralFileSamplingTester extends GeneralAlgorithmTester {
 	public File getSimpleProblemInputForGeneralTestPurposes() throws Exception {
 		OpenmlConnector client = new OpenmlConnector();
 		DataSetDescription description = client.dataGet(188);
-		File file = description.getDataset(OPENML_API_KEY);
+		File file = client.datasetGet(description);
 		return file;
 	}
 
 	public File getDifficultProblemInputForGeneralTestPurposes() throws Exception {
 		OpenmlConnector client = new OpenmlConnector();
 		DataSetDescription description = client.dataGet(182);
-		File file = description.getDataset(OPENML_API_KEY);
+		File file = client.datasetGet(description);
 		return file;
 	}
 

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/core/dataset/sampling/inmemory/SamplingAlgorithmTestProblemSet.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/core/dataset/sampling/inmemory/SamplingAlgorithmTestProblemSet.java
@@ -47,7 +47,7 @@ public class SamplingAlgorithmTestProblemSet<L> extends AAlgorithmTestProblemSet
 		OpenmlConnector client = new OpenmlConnector();
 		try {
 			DataSetDescription description = client.dataGet(id);
-			File file = description.getDataset(OPENML_API_KEY);
+			File file = client.datasetGet(description);
 			DataSource source = new DataSource(file.getCanonicalPath());
 			dataset = source.getDataSet();
 			dataset.setClassIndex(dataset.numAttributes() - 1);

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/evaluation/evaluators/weka/ExtrapolatedSaturationPointEvaluationTester.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/evaluation/evaluators/weka/ExtrapolatedSaturationPointEvaluationTester.java
@@ -32,7 +32,7 @@ public class ExtrapolatedSaturationPointEvaluationTester {
 		Instances dataset = null;
 		OpenmlConnector client = new OpenmlConnector();
 		DataSetDescription description = client.dataGet(42);
-		File file = description.getDataset("4350e421cdc16404033ef1812ea38c01");
+		File file = client.datasetGet(description);
 		DataSource source = new DataSource(file.getCanonicalPath());
 		dataset = source.getDataSet();
 		dataset.setClassIndex(dataset.numAttributes() - 1);

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/evaluation/evaluators/weka/LearningCurveExtrapolationEvaluationTester.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/evaluation/evaluators/weka/LearningCurveExtrapolationEvaluationTester.java
@@ -25,7 +25,7 @@ public class LearningCurveExtrapolationEvaluationTester {
 		Instances dataset = null;
 		OpenmlConnector client = new OpenmlConnector();
 		DataSetDescription description = client.dataGet(42);
-		File file = description.getDataset("4350e421cdc16404033ef1812ea38c01");
+		File file = client.datasetGet(description);
 		DataSource source = new DataSource(file.getCanonicalPath());
 		dataset = source.getDataSet();
 		dataset.setClassIndex(dataset.numAttributes() - 1);

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/learningcurve/extrapolation/AnchorpointsCreationTest.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/learningcurve/extrapolation/AnchorpointsCreationTest.java
@@ -30,7 +30,7 @@ public class AnchorpointsCreationTest {
 		OpenmlConnector client = new OpenmlConnector();
 		try {
 			DataSetDescription description = client.dataGet(42);
-			File file = description.getDataset("4350e421cdc16404033ef1812ea38c01");
+			File file = client.datasetGet(description);
 			DataSource source = new DataSource(file.getCanonicalPath());
 			dataset = source.getDataSet();
 			dataset.setClassIndex(dataset.numAttributes() - 1);

--- a/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/learningcurve/extrapolation/InversePowerLawExtrapolationTester.java
+++ b/JAICore/jaicore-ml/src/test/java/ai/libs/jaicore/ml/learningcurve/extrapolation/InversePowerLawExtrapolationTester.java
@@ -49,7 +49,7 @@ public class InversePowerLawExtrapolationTester {
 		OpenmlConnector client = new OpenmlConnector();
 		try {
 			DataSetDescription description = client.dataGet(42);
-			File file = description.getDataset("4350e421cdc16404033ef1812ea38c01");
+			File file = client.datasetGet(description);
 			DataSource source = new DataSource(file.getCanonicalPath());
 			dataset = source.getDataSet();
 			dataset.setClassIndex(dataset.numAttributes() - 1);

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ allprojects {
 
 	//Project properties
 	project.group = 'ai.libs'
-	project.version = '0.1.5'
+	project.version = '0.1.6'
 	
 	ext {
 	    ossrhUsername = project.hasProperty('ossrhUsername') ? ossrhUsername : System.getenv("ossrhUsername")
@@ -75,7 +75,6 @@ allprojects {
 		maven { url "https://jitpack.io" }
 		maven { url "http://clojars.org/repo/" }
 		maven { url "https://plugins.gradle.org/m2/" }
-		maven { url "https://nexus.cs.upb.de/repository/maven-releases/" }
 		flatDir {
 			dirs 'lib'
 		}

--- a/softwareconfiguration/autofe/build.gradle
+++ b/softwareconfiguration/autofe/build.gradle
@@ -31,13 +31,8 @@ dependencies {
 	compile group: 'org.openml', name: 'apiconnector', version: '1.0.18'
 
 	// servicification dependencies
-	compile group: 'de.upb.isys', name: 'interruptable-weka', version: '0.0.7'
-	compile group: 'de.upb.isys', name: 'meka', version: '0.0.1'
-	
-	//compile group: 'org.nd4j', name: 'nd4j-native-platform', version: '1.0.0-beta2'
-	//compile group: 'org.nd4j', name: 'nd4j-api', version: '1.0.0-beta2'
-	//compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta2'
-	//compile group: 'org.nd4j', name: 'nd4j-cuda-8.0-platform', version: '0.9.1'
+	compile 'ai.libs.thirdparty:interruptible-weka:0.1.2'
+	compile 'ai.libs.thirdparty:interruptible-meka:0.1.0'
 	
 	// Catalano
 	compile files('lib/Catalano.Image.jar')
@@ -49,6 +44,4 @@ dependencies {
 	compile "org.deeplearning4j:deeplearning4j-core:1.0.0-beta2"
 	compile "org.deeplearning4j:deeplearning4j-zoo:1.0.0-beta2"
 	compile "org.nd4j:nd4j-native-platform:1.0.0-beta2"
-	
-	// compile "org.deeplearning4j:deeplearning4j-cuda-8.0:1.0.0-beta"
 }

--- a/softwareconfiguration/hasco/src/main/java/ai/libs/hasco/core/HASCOFactory.java
+++ b/softwareconfiguration/hasco/src/main/java/ai/libs/hasco/core/HASCOFactory.java
@@ -58,7 +58,11 @@ public class HASCOFactory<S extends GraphSearchWithPathEvaluationsInput<N, A, V>
 	}
 
 	public void setPlanningGraphGeneratorDeriver(final IHierarchicalPlanningToGraphSearchReduction<N, A, ? super CEOCIPSTNPlanningProblem, ? extends IPlan, ? extends GraphSearchInput<N,A>, ? super SearchGraphPath<N,A>> planningGraphGeneratorDeriver) {
-		this.planningGraphGeneratorDeriver = (planningGraphGeneratorDeriver instanceof IHASCOPlanningReduction) ? (IHASCOPlanningReduction<N, A>)planningGraphGeneratorDeriver : new DefaultHASCOPlanningReduction<>(planningGraphGeneratorDeriver);
+		if(planningGraphGeneratorDeriver instanceof IHASCOPlanningReduction) {
+			this.planningGraphGeneratorDeriver = (IHASCOPlanningReduction<N, A>) planningGraphGeneratorDeriver;
+		} else {
+			this.planningGraphGeneratorDeriver = new DefaultHASCOPlanningReduction<N,A>(planningGraphGeneratorDeriver);
+		}
 	}
 
 	public IOptimalPathInORGraphSearchFactory<S, N, A, V> getSearchFactory() {

--- a/softwareconfiguration/mlplan/src/example/java/ai/libs/automl/mlplan/examples/MLPlanARFFExample.java
+++ b/softwareconfiguration/mlplan/src/example/java/ai/libs/automl/mlplan/examples/MLPlanARFFExample.java
@@ -56,7 +56,7 @@ public class MLPlanARFFExample {
 		builder.withNumCpus(2);
 
 		MLPlan mlplan = new MLPlan(builder, split.get(0));
-		mlplan.setPortionOfDataForPhase2(0f);
+		mlplan.setPortionOfDataForPhase2(.3f);
 		mlplan.setLoggerName("mlplan");
 
 		if (ACTIVATE_VISUALIZATION) {

--- a/softwareconfiguration/mlplan/src/example/java/ai/libs/automl/mlplan/examples/MetaMinerExample.java
+++ b/softwareconfiguration/mlplan/src/example/java/ai/libs/automl/mlplan/examples/MetaMinerExample.java
@@ -31,7 +31,7 @@ public class MetaMinerExample {
 		logger.info("Load data.");
 		OpenmlConnector connector = new OpenmlConnector();
 		DataSetDescription ds = connector.dataGet(40984);
-		File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
+		File file = connector.datasetGet(ds);
 		Instances data = new Instances(new BufferedReader(new FileReader(file)));
 		data.setClassIndex(data.numAttributes() - 1);
 		List<Instances> split = WekaUtil.getStratifiedSplit(data,0, .7f);

--- a/softwareconfiguration/mlplan/src/main/java/ai/libs/mlplan/core/MLPlan.java
+++ b/softwareconfiguration/mlplan/src/main/java/ai/libs/mlplan/core/MLPlan.java
@@ -222,7 +222,7 @@ public class MLPlan extends AAlgorithm<Instances, Classifier> implements ILoggin
 				}
 				long endBuildTime = System.currentTimeMillis();
 				this.logger.info("Selected model has been built on entire dataset. Build time of chosen model was {}ms. Total construction time was {}ms. The chosen classifier is: {}", endBuildTime - startBuildTime,
-						endBuildTime - startOptimizationTime, this.selectedClassifier);
+						endBuildTime - startOptimizationTime, this.getComponentInstanceOfSelectedClassifier());
 			} else {
 				this.logger.info("Selected model has not been built, since model building has been disabled. Total construction time was {}ms.", System.currentTimeMillis() - startOptimizationTime);
 			}

--- a/softwareconfiguration/mlplan/src/main/java/ai/libs/mlplan/metamining/dyadranking/WEKADyadRankedNodeQueueConfig.java
+++ b/softwareconfiguration/mlplan/src/main/java/ai/libs/mlplan/metamining/dyadranking/WEKADyadRankedNodeQueueConfig.java
@@ -84,10 +84,11 @@ public class WEKADyadRankedNodeQueueConfig extends ADyadRankedNodeQueueConfig<TF
 	 *
 	 * @param data
 	 *            the data to use
+	 * @throws Exception 
 	 */
-	public void setData(final Instances data) {
+	public void setData(final Instances data) throws Exception {
 		this.logger.trace("Setting data to instances of size {}", data.size());
-		this.contextCharacterization = this.datasetCharacterizer.characterize(data).entrySet().stream()
+		this.contextCharacterization = this.datasetCharacterizer.characterizeAll(data).entrySet().stream()
 				.mapToDouble(Map.Entry::getValue).toArray();
 	}
 

--- a/softwareconfiguration/mlplan/src/test/java/ai/libs/mlplan/test/cache/CacheTest.java
+++ b/softwareconfiguration/mlplan/src/test/java/ai/libs/mlplan/test/cache/CacheTest.java
@@ -29,7 +29,7 @@ public class CacheTest {
 
 			OpenmlConnector connector = new OpenmlConnector();
 			DataSetDescription ds = connector.dataGet(40983);
-			File file = ds.getDataset("4350e421cdc16404033ef1812ea38c01");
+			File file = connector.datasetGet(ds);
 			Instances data = new Instances(new BufferedReader(new FileReader(file)));
 			data.setClassIndex(data.numAttributes() - 1);
 


### PR DESCRIPTION
Reduce the number of dependencies to distinct lib repositories.
Currently there is the University's own Nexus, Maven Central, Jitpack, and Clojars

At least the dependency to the Nexus must be removed due to certificate issues depending on individually configured trust policies in other universities networks.